### PR TITLE
1. Cache-Busting for Discovery Endpoints (oauth_compat.py)

### DIFF
--- a/frappe_assistant_core/utils/oauth_compat.py
+++ b/frappe_assistant_core/utils/oauth_compat.py
@@ -40,12 +40,15 @@ def is_frappe_v16_or_later():
     )
 
 
-def get_oauth_settings():
+def get_oauth_settings(use_cache=True):
     """
     Get OAuth settings in a version-agnostic way.
 
     For v15: Reads from Assistant Core Settings
     For v16+: Reads from native OAuth Settings (frappe.integrations)
+
+    Args:
+            use_cache (bool): If False, bypasses cache and fetches fresh data. Default True.
 
     Returns:
             frappe._dict: Dictionary containing OAuth configuration with keys:
@@ -62,9 +65,13 @@ def get_oauth_settings():
     if is_frappe_v16_or_later():
         # Use native Frappe v16 OAuth Settings
         try:
-            oauth_settings = frappe.get_cached_doc(
-                "OAuth Settings", "OAuth Settings", ignore_permissions=True
-            )
+            if use_cache:
+                oauth_settings = frappe.get_cached_doc(
+                    "OAuth Settings", "OAuth Settings", ignore_permissions=True
+                )
+            else:
+                oauth_settings = frappe.get_doc("OAuth Settings", "OAuth Settings")
+
             return frappe._dict(
                 {
                     "show_auth_server_metadata": oauth_settings.show_auth_server_metadata,
@@ -90,9 +97,13 @@ def get_oauth_settings():
     else:
         # Use Frappe v15 - read from Assistant Core Settings
         try:
-            settings = frappe.get_cached_doc(
-                "Assistant Core Settings", "Assistant Core Settings", ignore_permissions=True
-            )
+            if use_cache:
+                settings = frappe.get_cached_doc(
+                    "Assistant Core Settings", "Assistant Core Settings", ignore_permissions=True
+                )
+            else:
+                settings = frappe.get_doc("Assistant Core Settings", "Assistant Core Settings")
+
             return frappe._dict(
                 {
                     "show_auth_server_metadata": settings.show_auth_server_metadata,


### PR DESCRIPTION
This pull request improves the handling of OAuth settings and the discovery endpoint in `frappe_assistant_core`. The main focus is to ensure that discovery endpoints always provide fresh data (not cached), and to enhance the parsing and logging of supported scopes. These changes help OAuth clients receive up-to-date configuration and more accurate metadata.

**OAuth settings cache control:**
* Added a `use_cache` parameter to the `get_oauth_settings` function, allowing callers to bypass cached data and fetch fresh settings for both Frappe v15 and v16. [[1]](diffhunk://#diff-4522020ea64afa24df30a4b803b36f11f40b8f60e2b06dde575b08efed88a12eL43-R52) [[2]](diffhunk://#diff-4522020ea64afa24df30a4b803b36f11f40b8f60e2b06dde575b08efed88a12eR68-R74) [[3]](diffhunk://#diff-4522020ea64afa24df30a4b803b36f11f40b8f60e2b06dde575b08efed88a12eR100-R106)
* Updated the `protected_resource_metadata` endpoint to call `get_oauth_settings(use_cache=False)`, ensuring clients always receive the latest configuration.

**Discovery endpoint improvements:**
* Enhanced parsing of the `scopes_supported` setting: now supports both newline- and space-separated scopes, removes duplicates, and only adds valid scopes to the metadata.
* Added debug logging to show which scopes are included in the protected resource metadata.