### PR TITLE
feature: Added support for v16 frappe framework

### DIFF
--- a/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.json
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.json
@@ -177,7 +177,8 @@
   {
    "fieldname": "oauth_tab",
    "fieldtype": "Tab Break",
-   "label": "OAuth"
+   "label": "OAuth",
+   "depends_on": "eval:!frappe.boot.versions?.frappe?.startsWith('16')"
   },
   {
    "fieldname": "oauth_authorization_section",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,6 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "frappe_assistant_core/plugins/base_plugin.py" = ["B027"]
+
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0,<17.0.0"


### PR DESCRIPTION
This pull request addresses compatibility issues with Frappe v16's OAuth client handling and improves the user interface logic for the OAuth tab in the Assistant Core settings. The main focus is to work around a bug in Frappe v16 related to redirect URI delimiters and ensure the returned OAuth client metadata conforms to RFC 7591.

OAuth client compatibility and bug fixes:

* In `frappe_assistant_core/utils/oauth_compat.py`, the `create_oauth_client` function now works around a Frappe v16 bug by converting the `redirect_uris` field from newline-delimited to space-delimited, ensuring compatibility with the validation logic in `oauth.py`. The function also formats the returned data as a dictionary following RFC 7591, including optional metadata fields if provided.

User interface improvements:

* In `frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.json`, the OAuth tab is now conditionally shown only if the Frappe version is not 16, improving the settings UI for users on different Frappe versions.