### PR TITLE
fix: Use frappe.utils.get_url() for consistent URL generation with port

### DIFF
--- a/frappe_assistant_core/api/fac_endpoint.py
+++ b/frappe_assistant_core/api/fac_endpoint.py
@@ -93,7 +93,6 @@ def _authenticate_mcp_request():
         str: Authenticated username
         None: Authentication failed (returns 401 response directly)
     """
-    from frappe.oauth import get_server_url
     from werkzeug.wrappers import Response
 
     auth_header = frappe.request.headers.get("Authorization", "")
@@ -129,7 +128,7 @@ def _authenticate_mcp_request():
         except frappe.DoesNotExistError:
             frappe.logger().error(f"OAuth Bearer Token not found for access_token: {token[:20]}...")
             # Token not found - return 401
-            frappe_url = get_server_url()
+            frappe_url = frappe.utils.get_url()
             metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
             response = Response()
@@ -150,7 +149,7 @@ def _authenticate_mcp_request():
             frappe.log_error(title="OAuth Token Validation Error", message=f"{type(e).__name__}: {str(e)}")
 
             # Return 401 for invalid/expired tokens
-            frappe_url = get_server_url()
+            frappe_url = frappe.utils.get_url()
             metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
             response = Response()
@@ -203,7 +202,7 @@ def _authenticate_mcp_request():
 
         except frappe.AuthenticationError as e:
             # Return 401 for invalid API credentials
-            frappe_url = get_server_url()
+            frappe_url = frappe.utils.get_url()
             metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
             response = Response()
@@ -220,7 +219,7 @@ def _authenticate_mcp_request():
             frappe.log_error(title="API Key Authentication Error", message=f"{type(e).__name__}: {str(e)}")
 
             # Return 401 for other errors
-            frappe_url = get_server_url()
+            frappe_url = frappe.utils.get_url()
             metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
             response = Response()
@@ -234,7 +233,7 @@ def _authenticate_mcp_request():
 
     # No valid authentication method found
     frappe.logger().warning("No valid authentication method found in request")
-    frappe_url = get_server_url()
+    frappe_url = frappe.utils.get_url()
     metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
     response = Response()
@@ -262,13 +261,12 @@ def handle_mcp():
     1. OAuth 2.0 Bearer tokens: "Authorization: Bearer <token>" (for web clients)
     2. API Key/Secret: "Authorization: token <api_key>:<api_secret>" (for STDIO clients)
     """
-    from frappe.oauth import get_server_url
     from werkzeug.wrappers import Response
 
     # Handle HEAD request for connectivity check (Claude Web uses this)
     if frappe.request.method == "HEAD":
         # Return 401 with WWW-Authenticate header to indicate auth is required
-        frappe_url = get_server_url()
+        frappe_url = frappe.utils.get_url()
         metadata_url = f"{frappe_url}/.well-known/oauth-protected-resource"
 
         response = Response()

--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -24,7 +24,6 @@ Extends Frappe's built-in OAuth endpoints with:
 """
 
 import frappe
-from frappe.oauth import get_server_url
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
@@ -51,7 +50,7 @@ def openid_configuration():
     metadata = frappe.local.response
 
     # Add MCP-required fields that are missing
-    frappe_url = get_server_url()
+    frappe_url = frappe.utils.get_url()
 
     # Add jwks_uri (required by MCP Inspector)
     metadata["jwks_uri"] = f"{frappe_url}/api/method/frappe_assistant_core.api.oauth_discovery.jwks"
@@ -104,7 +103,7 @@ def mcp_discovery():
     """
     from frappe_assistant_core import hooks
 
-    frappe_url = get_server_url()
+    frappe_url = frappe.utils.get_url()
 
     # Get MCP configuration from settings
     mcp_protocol_version = "2025-06-18"
@@ -148,7 +147,7 @@ def _get_frappe_authorization_server_metadata():
         return _get_authorization_server_metadata()
     except ImportError:
         # Fallback for Frappe V15 - build metadata manually
-        frappe_url = get_server_url()
+        frappe_url = frappe.utils.get_url()
 
         # Base metadata following RFC 8414
         metadata = {
@@ -198,7 +197,7 @@ def authorization_server_metadata():
     metadata = _get_frappe_authorization_server_metadata()
 
     # Add/override custom service documentation
-    frappe_url = get_server_url()
+    frappe_url = frappe.utils.get_url()
     metadata["service_documentation"] = "https://github.com/buildswithpaul/Frappe_Assistant_Core"
 
     # Add client_secret_post as an additional auth method (Frappe V16 only has client_secret_basic)
@@ -256,7 +255,7 @@ def protected_resource_metadata():
 
         raise NotFound("Protected resource metadata is not enabled")
 
-    frappe_url = get_server_url()
+    frappe_url = frappe.utils.get_url()
 
     # Build list of authorization servers
     authorization_servers = [frappe_url]


### PR DESCRIPTION
## Summary
- Replace `frappe.oauth.get_server_url()` with `frappe.utils.get_url()` in OAuth discovery endpoints and FAC endpoint
- Ensures server port is included in generated URLs (e.g., `:9000`)

## Problem
The `/.well-known/openid-configuration` endpoint was not including the server port in the generated URLs. This happened because `frappe.oauth.get_server_url()` returns the `base_url` from the "frappe" Social Login Key (which typically doesn't include the port), while `frappe.utils.get_url()` properly reads `host_name` and `webserver_port` from site configuration.

## Changes
- `frappe_assistant_core/api/oauth_discovery.py`: Removed import of `get_server_url`, replaced all calls with `frappe.utils.get_url()`
- `frappe_assistant_core/api/fac_endpoint.py`: Removed import of `get_server_url`, replaced all calls with `frappe.utils.get_url()`

## Testing
Verified that URLs in `/.well-known/openid-configuration` now correctly include the configured server port.

Fixes #101