### PR TITLE
fix: prevent OAuth Basic auth monkey-patch from persisting across worker requests

### DIFF
--- a/frappe_assistant_core/api/oauth_cors.py
+++ b/frappe_assistant_core/api/oauth_cors.py
@@ -320,6 +320,9 @@ def _handle_malformed_wellknown_url(request_path: str, request_method: str):
         raise ResponseException()
 
 
+_AUTH_PATCH_INSTALLED = False
+
+
 def _handle_oauth_token_endpoint_auth(request_path: str):
     """
     Bypass Frappe's API key validation for OAuth token endpoints.
@@ -328,11 +331,20 @@ def _handle_oauth_token_endpoint_auth(request_path: str):
     which is NOT a User API key. Frappe's validate_auth() incorrectly tries to
     validate this as a User API key and fails.
 
-    This function monkey-patches frappe.get_request_header to hide the
-    Authorization header from validate_auth() for OAuth token endpoints.
+    Uses a per-request flag on frappe.local (reset by Frappe at the start of
+    every request) so the bypass cannot leak into subsequent requests on the
+    same Gunicorn worker.
 
-    This runs in before_request hook, BEFORE validate_auth() is called.
+    This runs in the before_request hook, BEFORE validate_auth() is called.
     """
+    global _AUTH_PATCH_INSTALLED
+
+    # Install the wrapper once per worker process.
+    # All per-request decisions are gated on frappe.local, not re-patching.
+    if not _AUTH_PATCH_INSTALLED:
+        _install_auth_header_patch()
+        _AUTH_PATCH_INSTALLED = True
+
     # OAuth token endpoints that use client credentials in Basic auth
     oauth_token_endpoints = [
         "/api/method/frappe.integrations.oauth2.get_token",
@@ -349,22 +361,29 @@ def _handle_oauth_token_endpoint_auth(request_path: str):
     if not auth_header.startswith("Basic "):
         return
 
-    # Store original get_request_header function
+    # Set per-request flag. frappe.local is reset at the start of every request,
+    # so this flag cannot leak into subsequent requests.
+    frappe.local._bypass_oauth_basic_auth = True
+
+    frappe.logger().debug(
+        f"OAuth token endpoint: hiding Basic Authorization header from validate_auth() for {request_path}"
+    )
+
+
+def _install_auth_header_patch():
+    """
+    Install a one-time wrapper around frappe.get_request_header.
+
+    The wrapper defers to frappe.local._bypass_oauth_basic_auth to decide
+    whether to hide the Authorization header for the current request.
+    Safe to install once because all mutable state lives in frappe.local
+    (per-request), not in the closure.
+    """
     original_get_request_header = frappe.get_request_header
 
     def patched_get_request_header(key, default=None):
-        """
-        Patched version that hides Authorization header from validate_auth().
-
-        This prevents Frappe from treating OAuth client credentials as User API keys.
-        Our custom oauth_token.py endpoint reads the header directly from request.headers.
-        """
-        if key.lower() == "authorization":
-            # Hide the Basic auth header from Frappe's API key validation
+        if key.lower() == "authorization" and getattr(frappe.local, "_bypass_oauth_basic_auth", False):
             return default if default is not None else ""
         return original_get_request_header(key, default)
 
-    # Apply the monkey-patch
     frappe.get_request_header = patched_get_request_header
-
-    frappe.logger().debug(f"OAuth token endpoint auth bypass: hiding Authorization header for {request_path}")

--- a/frappe_assistant_core/change_log/v2/v2_3_4.md
+++ b/frappe_assistant_core/change_log/v2/v2_3_4.md
@@ -1,0 +1,4 @@
+## Version 2.3.4
+
+### Fixes
+- **OAuth auth isolation** — Fixed a critical bug where OAuth token requests permanently monkey-patched `frappe.get_request_header`, causing all subsequent API key authentication on the same Gunicorn worker to fail with 403. The fix uses a per-request flag on `frappe.local` that cannot leak across requests.

--- a/frappe_assistant_core/tests/test_oauth_cors.py
+++ b/frappe_assistant_core/tests/test_oauth_cors.py
@@ -1,0 +1,218 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for OAuth CORS handler — specifically the Authorization header bypass.
+
+These tests verify that the monkey-patch of frappe.get_request_header is
+properly scoped to individual requests and does not contaminate subsequent
+requests on the same Gunicorn worker.
+
+Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/129
+"""
+
+import base64
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from frappe_assistant_core.api.oauth_cors import (
+    _AUTH_PATCH_INSTALLED,
+    _handle_oauth_token_endpoint_auth,
+    _install_auth_header_patch,
+)
+
+
+class TestOAuthAuthHeaderBypass(unittest.TestCase):
+    """Tests for the OAuth Basic auth header bypass mechanism."""
+
+    def setUp(self):
+        """Reset module state before each test."""
+        import frappe_assistant_core.api.oauth_cors as cors_module
+
+        # Reset the patch-installed flag so each test starts clean
+        cors_module._AUTH_PATCH_INSTALLED = False
+
+        # Store the real get_request_header to restore after each test
+        self._original_get_request_header = frappe.get_request_header
+
+    def tearDown(self):
+        """Restore frappe.get_request_header to its original function."""
+        import frappe_assistant_core.api.oauth_cors as cors_module
+
+        frappe.get_request_header = self._original_get_request_header
+        cors_module._AUTH_PATCH_INSTALLED = False
+
+        # Clean up the per-request flag if set
+        if hasattr(frappe.local, "_bypass_oauth_basic_auth"):
+            del frappe.local._bypass_oauth_basic_auth
+
+    def _make_basic_auth_header(self, client_id: str = "test_client", client_secret: str = "test_secret"):
+        """Create a Basic auth header from client credentials."""
+        credentials = f"{client_id}:{client_secret}"
+        encoded = base64.b64encode(credentials.encode()).decode()
+        return f"Basic {encoded}"
+
+    def _mock_request(self, path: str, auth_header: str = ""):
+        """Set up a mock frappe.request for the given path and auth header."""
+        mock_request = MagicMock()
+        mock_request.path = path
+        mock_request.method = "POST"
+        mock_request.headers = {"Authorization": auth_header} if auth_header else {}
+        frappe.local.request = mock_request
+
+    def test_oauth_endpoint_hides_basic_auth_header(self):
+        """OAuth token endpoint with Basic auth should hide the Authorization header."""
+        basic_header = self._make_basic_auth_header()
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", basic_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+
+        # The patched function should hide the Authorization header
+        result = frappe.get_request_header("Authorization", "")
+        self.assertEqual(result, "", "Authorization header should be hidden for OAuth token endpoint")
+
+        # The flag should be set
+        self.assertTrue(getattr(frappe.local, "_bypass_oauth_basic_auth", False))
+
+    def test_non_oauth_endpoint_preserves_auth_header(self):
+        """Non-OAuth endpoints should pass the Authorization header through unchanged."""
+        api_key_header = "token api_key:api_secret"
+        self._mock_request("/api/method/frappe.client.get_list", api_key_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.client.get_list")
+
+        # The flag should NOT be set
+        self.assertFalse(getattr(frappe.local, "_bypass_oauth_basic_auth", False))
+
+        # Even after the patch is installed, non-OAuth requests should get the real header
+        result = frappe.get_request_header("Authorization", "")
+        self.assertEqual(
+            result, api_key_header, "Authorization header should pass through for non-OAuth endpoints"
+        )
+
+    def test_no_cross_request_contamination(self):
+        """
+        THE KEY REGRESSION TEST.
+
+        Simulates the exact bug from issue #129:
+        1. Request A: OAuth token endpoint with Basic auth → header hidden
+        2. Request B: Normal API endpoint with API key auth → header must be visible
+
+        In production, frappe.local is reset between requests by Frappe's init().
+        We simulate this by deleting the per-request flag.
+        """
+        # --- Request A: OAuth token endpoint ---
+        basic_header = self._make_basic_auth_header()
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", basic_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+
+        # Verify header is hidden during Request A
+        result_a = frappe.get_request_header("Authorization", "")
+        self.assertEqual(result_a, "", "Request A: Authorization header should be hidden")
+
+        # --- Simulate new request (frappe.local reset) ---
+        # In production, frappe.init() resets frappe.local between requests.
+        # We simulate this by removing the per-request flag.
+        if hasattr(frappe.local, "_bypass_oauth_basic_auth"):
+            del frappe.local._bypass_oauth_basic_auth
+
+        # --- Request B: Normal API endpoint with API key auth ---
+        api_key_header = "token api_key:api_secret"
+        self._mock_request("/api/method/frappe.client.get_list", api_key_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.client.get_list")
+
+        # Verify header is NOT hidden during Request B
+        result_b = frappe.get_request_header("Authorization", "")
+        self.assertEqual(
+            result_b,
+            api_key_header,
+            "Request B: Authorization header must be visible after OAuth request on same worker",
+        )
+
+    def test_non_basic_auth_not_intercepted(self):
+        """OAuth endpoint with Bearer token (not Basic) should NOT trigger the bypass."""
+        bearer_header = "Bearer some_access_token"
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", bearer_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+
+        # The flag should NOT be set — Bearer auth is not client credentials
+        self.assertFalse(getattr(frappe.local, "_bypass_oauth_basic_auth", False))
+
+    def test_revoke_endpoint_also_bypassed(self):
+        """The revoke_token endpoint should also bypass auth validation."""
+        basic_header = self._make_basic_auth_header()
+        self._mock_request("/api/method/frappe.integrations.oauth2.revoke_token", basic_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.revoke_token")
+
+        result = frappe.get_request_header("Authorization", "")
+        self.assertEqual(result, "", "Authorization header should be hidden for revoke endpoint")
+
+    def test_introspect_endpoint_also_bypassed(self):
+        """The introspect_token endpoint should also bypass auth validation."""
+        basic_header = self._make_basic_auth_header()
+        self._mock_request("/api/method/frappe.integrations.oauth2.introspect_token", basic_header)
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.introspect_token")
+
+        result = frappe.get_request_header("Authorization", "")
+        self.assertEqual(result, "", "Authorization header should be hidden for introspect endpoint")
+
+    def test_patch_installed_only_once(self):
+        """The wrapper should be installed only once, not re-installed on every request."""
+        import frappe_assistant_core.api.oauth_cors as cors_module
+
+        basic_header = self._make_basic_auth_header()
+
+        # First request — patch gets installed
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", basic_header)
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+        self.assertTrue(cors_module._AUTH_PATCH_INSTALLED)
+
+        # Capture the function reference after first install
+        patched_fn = frappe.get_request_header
+
+        # Simulate new request
+        if hasattr(frappe.local, "_bypass_oauth_basic_auth"):
+            del frappe.local._bypass_oauth_basic_auth
+
+        # Second request — patch should NOT be re-installed
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", basic_header)
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+
+        # Same function reference — not wrapped again
+        self.assertIs(
+            frappe.get_request_header,
+            patched_fn,
+            "Patch should be installed once, not re-wrapped on every request",
+        )
+
+    def test_other_headers_unaffected(self):
+        """Non-Authorization headers should always pass through regardless of bypass state."""
+        basic_header = self._make_basic_auth_header()
+        self._mock_request("/api/method/frappe.integrations.oauth2.get_token", basic_header)
+        frappe.local.request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        _handle_oauth_token_endpoint_auth("/api/method/frappe.integrations.oauth2.get_token")
+
+        # Other headers should be unaffected
+        result = frappe.get_request_header("Content-Type", "")
+        self.assertEqual(result, "application/x-www-form-urlencoded")


### PR DESCRIPTION
## Summary

- **Fixes** a critical bug where OAuth token requests permanently monkey-patched `frappe.get_request_header`, causing all subsequent API key authentication on the same Gunicorn worker to fail with 403
- Replaces the permanent module-level mutation with a **per-request flag** on `frappe.local` (`_bypass_oauth_basic_auth`) that cannot leak across requests
- Adds **8 regression tests** covering cross-request contamination, all 3 OAuth token endpoints, Bearer-vs-Basic distinction, and patch idempotency

## Root Cause

`_handle_oauth_token_endpoint_auth()` replaced `frappe.get_request_header` with a version that always returned empty string for the `Authorization` header. Since Gunicorn workers persist across requests, this patch survived into subsequent non-OAuth requests, breaking API key validation.

## Fix

- Install the wrapper **once per worker** via `_install_auth_header_patch()` (guarded by `_AUTH_PATCH_INSTALLED`)
- The wrapper only hides the header when `frappe.local._bypass_oauth_basic_auth` is `True`
- `frappe.local` is reset by Frappe at the start of every request — the flag cannot leak

## Test plan

- [x] `bench --site frappe.assistant run-tests --module frappe_assistant_core.tests.test_oauth_cors` — 8/8 pass
- [x] `bench --site frappe.assistant run-tests --app frappe_assistant_core` — 112/112 pass (53 skipped)
- [ ] Manual: hit OAuth token endpoint with Basic auth, then hit any API endpoint with API key auth — should get 200

Fixes #129