### PR TITLE
fix: remove unprotected whitelist decorators from duplicate config endpoints

### DIFF
--- a/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
@@ -332,7 +332,6 @@ class AssistantCoreSettings(Document):
 # Use StreamableHTTP (OAuth-based) transport instead
 
 
-@frappe.whitelist()
 def toggle_plugin_api(plugin_name: str, action: str):
     """
     Standalone API to enable or disable a plugin.

--- a/frappe_assistant_core/assistant_core/doctype/fac_plugin_configuration/fac_plugin_configuration.py
+++ b/frappe_assistant_core/assistant_core/doctype/fac_plugin_configuration/fac_plugin_configuration.py
@@ -54,7 +54,7 @@ class FACPluginConfiguration(Document):
         frappe.clear_document_cache("Assistant Core Settings", "Assistant Core Settings")
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_plugin_enabled_status(plugin_name: str) -> dict:
     """
     Check if a plugin is enabled.
@@ -65,6 +65,8 @@ def get_plugin_enabled_status(plugin_name: str) -> dict:
     Returns:
         Dict with enabled status
     """
+    frappe.only_for(["System Manager", "Assistant Admin"])
+
     try:
         if frappe.db.exists("FAC Plugin Configuration", plugin_name):
             enabled = frappe.db.get_value("FAC Plugin Configuration", plugin_name, "enabled")
@@ -90,7 +92,6 @@ def get_plugin_enabled_status(plugin_name: str) -> dict:
         }
 
 
-@frappe.whitelist()
 def toggle_plugin_state(plugin_name: str, enabled: bool) -> dict:
     """
     Enable or disable a plugin.
@@ -133,7 +134,7 @@ def toggle_plugin_state(plugin_name: str, enabled: bool) -> dict:
         return {"success": False, "message": str(e)}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_all_plugin_configurations() -> dict:
     """
     Get all plugin configurations.
@@ -141,6 +142,8 @@ def get_all_plugin_configurations() -> dict:
     Returns:
         Dict with list of plugin configurations
     """
+    frappe.only_for(["System Manager", "Assistant Admin"])
+
     try:
         configs = frappe.get_all(
             "FAC Plugin Configuration",

--- a/frappe_assistant_core/assistant_core/doctype/fac_tool_configuration/fac_tool_configuration.py
+++ b/frappe_assistant_core/assistant_core/doctype/fac_tool_configuration/fac_tool_configuration.py
@@ -98,7 +98,7 @@ class FACToolConfiguration(Document):
         return False
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_tool_access_status(tool_name: str, user: str = None) -> dict:
     """
     Check if a user has access to a specific tool.
@@ -110,6 +110,8 @@ def get_tool_access_status(tool_name: str, user: str = None) -> dict:
     Returns:
         Dict with access status and reason
     """
+    frappe.only_for(["System Manager", "Assistant Admin"])
+
     user = user or frappe.session.user
 
     try:
@@ -137,7 +139,6 @@ def get_tool_access_status(tool_name: str, user: str = None) -> dict:
         }
 
 
-@frappe.whitelist()
 def toggle_tool(tool_name: str, enabled: bool) -> dict:
     """
     Enable or disable a tool.
@@ -170,7 +171,6 @@ def toggle_tool(tool_name: str, enabled: bool) -> dict:
         return {"success": False, "message": str(e)}
 
 
-@frappe.whitelist()
 def bulk_toggle_tools(tool_names: list, enabled: bool) -> dict:
     """
     Enable or disable multiple tools at once.


### PR DESCRIPTION
## Summary

- **Removes** `@frappe.whitelist()` from 4 state-changing DocType endpoints that duplicate protected admin_api.py versions: `toggle_plugin_state`, `toggle_tool`, `bulk_toggle_tools`, `toggle_plugin_api`
- **Adds** `frappe.only_for(["System Manager", "Assistant Admin"])` to 3 read-only DocType endpoints: `get_plugin_enabled_status`, `get_all_plugin_configurations`, `get_tool_access_status`
- **Adds** `methods=["GET"]` to read-only endpoint decorators per coding standards

## Root Cause

The DocType-level endpoints were created before `admin_api.py` centralized configuration management. They lacked role enforcement and used `ignore_permissions=True`, allowing any authenticated user to toggle plugins/tools.

## Files Changed

- `assistant_core/doctype/fac_plugin_configuration/fac_plugin_configuration.py` — remove whitelist from `toggle_plugin_state`, add `only_for` to reads
- `assistant_core/doctype/fac_tool_configuration/fac_tool_configuration.py` — remove whitelist from `toggle_tool` and `bulk_toggle_tools`, add `only_for` to reads
- `assistant_core/doctype/assistant_core_settings/assistant_core_settings.py` — remove whitelist from `toggle_plugin_api`

## Test plan

- [x] No internal callers rely on the removed whitelist endpoints (grep verified)
- [x] Protected equivalents in `admin_api.py` already handle all admin operations
- [ ] `bench --site <site> run-tests --app frappe_assistant_core` passes
- [ ] Calling removed endpoints as non-admin returns 403 (function not whitelisted)

Fixes #124