### PR TITLE
fix: enforce parent document permission check in extract_file_content

### DIFF
--- a/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
+++ b/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
@@ -206,28 +206,59 @@ class ExtractFileContent(BaseTool):
         return {"success": True}
 
     def _get_file_document(self, arguments: Dict[str, Any]) -> Optional[Any]:
-        """Get file document from Frappe"""
+        """Get file document from Frappe, with parent document authorization."""
         file_url = arguments.get("file_url")
         file_name = arguments.get("file_name")
 
         try:
+            file_doc = None
+
             if file_url:
-                # Get file by URL
-                file_doc = frappe.get_all("File", filters={"file_url": file_url}, fields=["*"], limit=1)
-                if file_doc:
-                    return frappe.get_doc("File", file_doc[0].name)
+                results = frappe.get_all("File", filters={"file_url": file_url}, fields=["*"], limit=1)
+                if results:
+                    file_doc = frappe.get_doc("File", results[0].name)
 
             elif file_name:
-                # Get file by name
-                file_doc = frappe.get_all("File", filters={"file_name": file_name}, fields=["*"], limit=1)
-                if file_doc:
-                    return frappe.get_doc("File", file_doc[0].name)
+                results = frappe.get_all("File", filters={"file_name": file_name}, fields=["*"], limit=1)
+                if results:
+                    file_doc = frappe.get_doc("File", results[0].name)
 
-            return None
+            if not file_doc:
+                return None
 
+            self._check_file_access(file_doc)
+            return file_doc
+
+        except frappe.PermissionError:
+            raise
         except Exception as e:
             frappe.log_error(f"Error getting file document: {str(e)}")
             return None
+
+    def _check_file_access(self, file_doc) -> None:
+        """
+        Verify the user has access to a file's parent document.
+
+        Beyond the generic File DocType read permission (checked by
+        requires_permission = "File"), this ensures the user can actually
+        read the document the file is attached to.
+
+        Raises:
+            frappe.PermissionError: If user cannot access the parent document
+                or if a private unattached file is accessed by a non-admin.
+        """
+        # If attached to a document, check parent document permission
+        if file_doc.attached_to_doctype and file_doc.attached_to_name:
+            if not frappe.has_permission(file_doc.attached_to_doctype, "read", file_doc.attached_to_name):
+                frappe.throw(
+                    _("You do not have permission to access the document this file is attached to"),
+                    frappe.PermissionError,
+                )
+            return
+
+        # Private unattached files require System Manager
+        if file_doc.file_url and "/private/" in file_doc.file_url:
+            frappe.only_for("System Manager")
 
     def _check_file_size(self, file_doc) -> bool:
         """Check if file size is within limits"""


### PR DESCRIPTION
## Summary

- Adds parent document authorization to \`extract_file_content\` tool via new \`_check_file_access()\` method
- If a file is attached to a document (\`attached_to_doctype\` + \`attached_to_name\`), verifies the user has read permission on that parent document before reading content
- Private unattached files (\`/private/\`) now require System Manager role

## Root Cause

The tool set \`requires_permission = "File"\` which only checked generic File DocType read permission via \`frappe.has_permission("File", "read")\`. This allowed any user with File read access to extract content from private attachments on documents they couldn't access (e.g., reading a file attached to an Invoice they have no permission to view).

## Test plan

- [x] \`bench --site <site> run-tests --app frappe_assistant_core\` passes
- [x] As non-admin user: attempt to read a file attached to a doc the user can't access → PermissionError
- [ ] As admin user: read the same file → succeeds
- [ ] Public files (not in /private/) without parent doc → still accessible (no regression)

Fixes #126