### PR TITLE
fix: toggle checkbox stays disabled after publish/unpublish

### DIFF
--- a/frappe_assistant_core/public/js/fac_admin_prompts.js
+++ b/frappe_assistant_core/public/js/fac_admin_prompts.js
@@ -120,6 +120,9 @@
             method: "frappe_assistant_core.api.admin_api.toggle_prompt_template_status",
             args: { name: name, publish: publish ? 1 : 0 },
             callback: function(response) {
+                delete ns.state.toggleInProgress[stateKey];
+                ns.state.autoRefreshEnabled = true;
+
                 if (response.message && response.message.success) {
                     frappe.show_alert({ message: response.message.message, indicator: publish ? 'green' : 'orange' });
                     const tmpl = ns.state.promptsData.find(t => t.name === name);
@@ -128,18 +131,18 @@
                     ns.loadStats();
                 } else {
                     checkbox.prop('checked', originalState);
+                    checkbox.prop('disabled', false);
+                    checkbox.closest('.fac-item-card').removeClass('toggle-in-progress');
                     frappe.show_alert({ message: response.message?.message || 'Unknown error', indicator: 'red' });
                 }
             },
             error: function() {
-                checkbox.prop('checked', originalState);
-                frappe.show_alert({ message: 'Error toggling template status', indicator: 'red' });
-            },
-            always: function() {
                 delete ns.state.toggleInProgress[stateKey];
                 ns.state.autoRefreshEnabled = true;
+                checkbox.prop('checked', originalState);
                 checkbox.prop('disabled', false);
                 checkbox.closest('.fac-item-card').removeClass('toggle-in-progress');
+                frappe.show_alert({ message: 'Error toggling template status', indicator: 'red' });
             }
         });
     };

--- a/frappe_assistant_core/public/js/fac_admin_skills.js
+++ b/frappe_assistant_core/public/js/fac_admin_skills.js
@@ -123,6 +123,9 @@
             method: "frappe_assistant_core.api.admin_api.toggle_skill_status",
             args: { name: name, publish: publish ? 1 : 0 },
             callback: function(response) {
+                delete ns.state.toggleInProgress[stateKey];
+                ns.state.autoRefreshEnabled = true;
+
                 if (response.message && response.message.success) {
                     frappe.show_alert({ message: response.message.message, indicator: publish ? 'green' : 'orange' });
                     const skill = ns.state.skillsData.find(s => s.name === name);
@@ -131,18 +134,18 @@
                     ns.loadStats();
                 } else {
                     checkbox.prop('checked', originalState);
+                    checkbox.prop('disabled', false);
+                    checkbox.closest('.fac-item-card').removeClass('toggle-in-progress');
                     frappe.show_alert({ message: response.message?.message || 'Unknown error', indicator: 'red' });
                 }
             },
             error: function() {
-                checkbox.prop('checked', originalState);
-                frappe.show_alert({ message: 'Error toggling skill status', indicator: 'red' });
-            },
-            always: function() {
                 delete ns.state.toggleInProgress[stateKey];
                 ns.state.autoRefreshEnabled = true;
+                checkbox.prop('checked', originalState);
                 checkbox.prop('disabled', false);
                 checkbox.closest('.fac-item-card').removeClass('toggle-in-progress');
+                frappe.show_alert({ message: 'Error toggling skill status', indicator: 'red' });
             }
         });
     };


### PR DESCRIPTION
## Summary

Fixes a bug where the publish/unpublish toggle on Prompt Templates and Skills tabs becomes permanently disabled after the first toggle.

## Root cause

After a successful toggle, `renderPromptTemplatesList()` / `renderSkillsList()` replaces all DOM elements. But `toggleInProgress[key]` was only cleared in the `always` callback — which fires **after** the re-render has already checked it and created the new checkbox with `disabled` attribute. The `always` callback then operates on stale (detached) DOM references, leaving the new checkbox stuck as disabled.

## Fix

Clear `toggleInProgress` state **before** calling `renderList()` in the `callback`, so newly created DOM elements are rendered with `disabled: false`. On error, clean up state and DOM inline since no re-render occurs. Removed the `always` callback entirely.

## Files changed

- `public/js/fac_admin_prompts.js` — moved state cleanup from `always` to `callback`/`error`
- `public/js/fac_admin_skills.js` — same fix

## Test plan

- [x] Toggle a prompt template off (unpublish) — checkbox stays clickable
- [x] Toggle it back on (publish) — checkbox stays clickable
- [x] Toggle a skill off then on — same behavior
- [x] Rapid double-click still blocked (toggleInProgress guard)


🤖 Generated with [Claude Code](https://claude.com/claude-code)