### PR TITLE
fix: restrict usage statistics to assistant admins

### DIFF
--- a/frappe_assistant_core/api/admin_api.py
+++ b/frappe_assistant_core/api/admin_api.py
@@ -189,6 +189,13 @@ def toggle_plugin(plugin_name: str, enable: bool):
 def get_usage_statistics():
     """Get usage statistics for the assistant."""
     from frappe_assistant_core.utils.logger import api_logger
+    from frappe_assistant_core.utils.permissions import check_assistant_admin_permission
+
+    if not check_assistant_admin_permission(frappe.session.user):
+        api_logger.warning(
+            f"Usage statistics denied for non-admin user: {frappe.session.user} "
+            f"with roles: {frappe.get_roles(frappe.session.user)}"
+        )
 
     frappe.only_for(["System Manager", "Assistant Admin"])
 

--- a/frappe_assistant_core/api/admin_api.py
+++ b/frappe_assistant_core/api/admin_api.py
@@ -189,12 +189,10 @@ def toggle_plugin(plugin_name: str, enable: bool):
 def get_usage_statistics():
     """Get usage statistics for the assistant."""
     from frappe_assistant_core.utils.logger import api_logger
-    from frappe_assistant_core.utils.permissions import check_assistant_permission
+
+    frappe.only_for(["System Manager", "Assistant Admin"])
 
     try:
-        if not check_assistant_permission(frappe.session.user):
-            frappe.throw(_("Access denied - insufficient permissions"))
-
         api_logger.info(f"Usage statistics requested by user: {frappe.session.user}")
 
         today = frappe.utils.today()

--- a/frappe_assistant_core/api/assistant_api.py
+++ b/frappe_assistant_core/api/assistant_api.py
@@ -36,15 +36,17 @@ def get_usage_statistics() -> Dict[str, Any]:
             api_logger.warning("Usage statistics requested without valid authentication")
             frappe.throw(_("Authentication required"))
 
-        # SECURITY: Check if user has assistant access
-        from frappe_assistant_core.utils.permissions import check_assistant_permission
+        # SECURITY: Restrict global usage statistics to assistant admins
+        from frappe_assistant_core.utils.permissions import check_assistant_admin_permission
 
         user_roles = frappe.get_roles(authenticated_user)
         api_logger.debug(f"User {authenticated_user} has roles: {user_roles}")
 
-        if not check_assistant_permission(authenticated_user):
-            api_logger.warning(f"Access denied for user: {authenticated_user} with roles: {user_roles}")
-            frappe.throw(_("Access denied - insufficient permissions"))
+        if not check_assistant_admin_permission(authenticated_user):
+            api_logger.warning(
+                f"Usage statistics denied for non-admin user: {authenticated_user} with roles: {user_roles}"
+            )
+            frappe.throw(_("Access denied - administrator permissions required"))
 
         api_logger.info(f"Usage statistics requested by user: {authenticated_user}")
         api_logger.info(f"Current site: {frappe.local.site}")

--- a/frappe_assistant_core/tests/base_test.py
+++ b/frappe_assistant_core/tests/base_test.py
@@ -19,6 +19,7 @@ Base test class for Frappe Assistant Core tests
 Provides common setup and utilities for all test classes
 """
 
+from contextlib import contextmanager
 import json
 import unittest
 from unittest.mock import MagicMock, patch
@@ -103,6 +104,31 @@ class BaseAssistantTest(unittest.TestCase):
         """Clean up after each test"""
         self.clear_test_data()
         self.cleanup_mocks()
+
+    @contextmanager
+    def enforce_only_for_checks(self):
+        """Run code with Frappe's test-mode permission shortcut disabled."""
+        sentinel = object()
+        flags = getattr(frappe.local, "flags", None)
+        created_flags = flags is None
+
+        if created_flags:
+            frappe.local.flags = frappe._dict()
+            flags = frappe.local.flags
+
+        original_in_test = getattr(flags, "in_test", sentinel)
+        flags.in_test = False
+
+        try:
+            yield
+        finally:
+            if original_in_test is sentinel:
+                flags.pop("in_test", None)
+            else:
+                flags.in_test = original_in_test
+
+            if created_flags and not flags:
+                del frappe.local.flags
 
     def _ensure_plugins_enabled(self):
         """Ensure core plugins are enabled for testing"""

--- a/frappe_assistant_core/tests/base_test.py
+++ b/frappe_assistant_core/tests/base_test.py
@@ -19,9 +19,9 @@ Base test class for Frappe Assistant Core tests
 Provides common setup and utilities for all test classes
 """
 
-from contextlib import contextmanager
 import json
 import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import frappe

--- a/frappe_assistant_core/tests/test_admin_api_permissions.py
+++ b/frappe_assistant_core/tests/test_admin_api_permissions.py
@@ -21,8 +21,6 @@ Ensures that non-admin users cannot access admin endpoints.
 Ref: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/105
 """
 
-from unittest.mock import patch
-
 import frappe
 
 from frappe_assistant_core.tests.base_test import BaseAssistantTest
@@ -89,14 +87,14 @@ class TestAdminAPIPermissions(BaseAssistantTest):
         frappe.set_user(self.NON_ADMIN_USER)
         frappe.clear_cache(user=self.NON_ADMIN_USER)
 
-        with patch.object(frappe.flags, "in_test", False):
+        with self.enforce_only_for_checks():
             with self.assertRaises(frappe.PermissionError):
                 func(*args, **kwargs)
 
     def _assert_allowed_for_admin(self, func, *args, **kwargs):
         """Assert that calling func as Administrator does NOT raise PermissionError."""
         frappe.set_user("Administrator")
-        with patch.object(frappe.flags, "in_test", False):
+        with self.enforce_only_for_checks():
             try:
                 func(*args, **kwargs)
             except frappe.PermissionError:

--- a/frappe_assistant_core/tests/test_admin_api_permissions.py
+++ b/frappe_assistant_core/tests/test_admin_api_permissions.py
@@ -21,30 +21,11 @@ Ensures that non-admin users cannot access admin endpoints.
 Ref: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/105
 """
 
-import unittest
+from unittest.mock import patch
 
 import frappe
 
 from frappe_assistant_core.tests.base_test import BaseAssistantTest
-
-
-def _strict_only_for(roles, message=False):
-    """frappe.only_for replacement that enforces checks even during tests.
-
-    The real frappe.only_for skips all checks when local.flags.in_test is True,
-    making it impossible to test permission enforcement in the test runner.
-    """
-    if frappe.session.user == "Administrator":
-        return
-    if isinstance(roles, str):
-        roles = (roles,)
-    if set(roles).isdisjoint(frappe.get_roles()):
-        if not message:
-            raise frappe.PermissionError
-        frappe.throw(
-            f"This action is only allowed for {', '.join(roles)}",
-            frappe.PermissionError,
-        )
 
 
 class TestAdminAPIPermissions(BaseAssistantTest):
@@ -102,33 +83,27 @@ class TestAdminAPIPermissions(BaseAssistantTest):
     def _assert_blocked_for_non_admin(self, func, *args, **kwargs):
         """Assert that calling func as a non-admin user raises PermissionError.
 
-        Directly monkeypatches frappe.only_for to bypass the in_test skip
-        that frappe applies during test runs.
+        Temporarily disables Frappe's test-mode shortcut so the real
+        frappe.only_for permission check executes.
         """
         frappe.set_user(self.NON_ADMIN_USER)
         frappe.clear_cache(user=self.NON_ADMIN_USER)
-        original = frappe.only_for
-        frappe.only_for = _strict_only_for
-        try:
+
+        with patch.object(frappe.flags, "in_test", False):
             with self.assertRaises(frappe.PermissionError):
                 func(*args, **kwargs)
-        finally:
-            frappe.only_for = original
 
     def _assert_allowed_for_admin(self, func, *args, **kwargs):
         """Assert that calling func as Administrator does NOT raise PermissionError."""
         frappe.set_user("Administrator")
-        original = frappe.only_for
-        frappe.only_for = _strict_only_for
-        try:
-            func(*args, **kwargs)
-        except frappe.PermissionError:
-            self.fail(f"{func.__name__} should be allowed for Administrator but raised PermissionError")
-        except Exception:
-            # Other errors (e.g. missing tool) are fine — we're only testing auth
-            pass
-        finally:
-            frappe.only_for = original
+        with patch.object(frappe.flags, "in_test", False):
+            try:
+                func(*args, **kwargs)
+            except frappe.PermissionError:
+                self.fail(f"{func.__name__} should be allowed for Administrator but raised PermissionError")
+            except Exception:
+                # Other errors (e.g. missing tool) are fine — we're only testing auth
+                pass
 
     # =========================================================================
     # State-changing endpoints (POST-only)

--- a/frappe_assistant_core/tests/test_usage_statistics_permissions.py
+++ b/frappe_assistant_core/tests/test_usage_statistics_permissions.py
@@ -1,0 +1,159 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for usage statistics endpoint permissions."""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+
+def _strict_only_for(roles, message=False):
+    """frappe.only_for replacement that enforces checks during tests."""
+    if frappe.session.user == "Administrator":
+        return
+    if isinstance(roles, str):
+        roles = (roles,)
+    if set(roles).isdisjoint(frappe.get_roles()):
+        if not message:
+            raise frappe.PermissionError
+        frappe.throw(
+            f"This action is only allowed for {', '.join(roles)}",
+            frappe.PermissionError,
+        )
+
+
+class TestUsageStatisticsPermissions(BaseAssistantTest):
+    """Ensure usage statistics are restricted to assistant admins."""
+
+    ASSISTANT_USER = "test_assistant_user@example.com"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._create_assistant_user()
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.set_user("Administrator")
+        if frappe.db.exists("User", cls.ASSISTANT_USER):
+            frappe.delete_doc("User", cls.ASSISTANT_USER, force=True)
+        super().tearDownClass()
+
+    @classmethod
+    def _create_assistant_user(cls):
+        if frappe.db.exists("User", cls.ASSISTANT_USER):
+            frappe.delete_doc("User", cls.ASSISTANT_USER, force=True)
+
+        user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": cls.ASSISTANT_USER,
+                "first_name": "Assistant",
+                "last_name": "User",
+                "enabled": 1,
+                "new_password": "test_password_123",
+                "user_type": "System User",
+            }
+        )
+        user.append("roles", {"role": "Assistant User"})
+        user.insert(ignore_permissions=True)
+        frappe.clear_cache(user=cls.ASSISTANT_USER)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+    def test_admin_usage_statistics_blocked_for_assistant_user(self):
+        """Assistant User cannot access admin usage statistics."""
+        from frappe_assistant_core.api.admin_api import get_usage_statistics
+
+        frappe.set_user(self.ASSISTANT_USER)
+        frappe.clear_cache(user=self.ASSISTANT_USER)
+        original_only_for = frappe.only_for
+        frappe.only_for = _strict_only_for
+        try:
+            with self.assertRaises(frappe.PermissionError):
+                get_usage_statistics()
+        finally:
+            frappe.only_for = original_only_for
+
+    def test_admin_usage_statistics_allowed_for_admin(self):
+        """Administrator can access admin usage statistics."""
+        from frappe_assistant_core.api.admin_api import get_usage_statistics
+
+        mock_plugin_manager = MagicMock()
+        mock_plugin_manager.get_all_tools.return_value = {"sample_tool": object()}
+
+        frappe.set_user("Administrator")
+        with patch(
+            "frappe_assistant_core.api.admin_api.frappe.db.count",
+            side_effect=[3, 1, 2],
+        ), patch(
+            "frappe_assistant_core.api.admin_api.frappe.db.get_list",
+            return_value=[],
+        ), patch(
+            "frappe_assistant_core.utils.plugin_manager.get_plugin_manager",
+            return_value=mock_plugin_manager,
+        ):
+            response = get_usage_statistics()
+
+        self.assertTrue(response["success"])
+        self.assertEqual(response["data"]["audit_logs"]["total"], 3)
+        self.assertEqual(response["data"]["tools"]["total"], 1)
+
+    def test_assistant_usage_statistics_blocked_for_assistant_user(self):
+        """Assistant User cannot access global usage statistics."""
+        from frappe_assistant_core.api.assistant_api import get_usage_statistics
+
+        frappe.set_user(self.ASSISTANT_USER)
+        with patch(
+            "frappe_assistant_core.api.assistant_api._authenticate_request",
+            return_value=self.ASSISTANT_USER,
+        ):
+            response = get_usage_statistics()
+
+        self.assertFalse(response["success"])
+        self.assertIn("administrator permissions required", response["error"])
+
+    def test_assistant_usage_statistics_allowed_for_admin(self):
+        """Administrator can access assistant usage statistics."""
+        from frappe_assistant_core.api.assistant_api import get_usage_statistics
+
+        mock_plugin_manager = MagicMock()
+        mock_plugin_manager.get_all_tools.return_value = {"sample_tool": object()}
+
+        frappe.set_user("Administrator")
+        with patch(
+            "frappe_assistant_core.api.assistant_api._authenticate_request",
+            return_value="Administrator",
+        ), patch(
+            "frappe_assistant_core.api.assistant_api.frappe.db.count",
+            side_effect=[3, 1, 2, 3, 1, 2],
+        ), patch(
+            "frappe_assistant_core.api.assistant_api.frappe.db.get_list",
+            return_value=[],
+        ), patch(
+            "frappe_assistant_core.utils.plugin_manager.get_plugin_manager",
+            return_value=mock_plugin_manager,
+        ):
+            response = get_usage_statistics()
+
+        self.assertTrue(response["success"])
+        self.assertEqual(response["data"]["audit_logs"]["total"], 3)
+        self.assertEqual(response["data"]["tools"]["enabled"], 1)

--- a/frappe_assistant_core/tests/test_usage_statistics_permissions.py
+++ b/frappe_assistant_core/tests/test_usage_statistics_permissions.py
@@ -71,7 +71,7 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
         frappe.set_user(self.ASSISTANT_USER)
         frappe.clear_cache(user=self.ASSISTANT_USER)
 
-        with patch.object(frappe.flags, "in_test", False):
+        with self.enforce_only_for_checks():
             with self.assertRaises(frappe.PermissionError):
                 get_usage_statistics()
 
@@ -84,7 +84,7 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
         audit_stat_counts = [3, 1, 2]  # audit log total, today, this week
 
         frappe.set_user("Administrator")
-        with patch.object(frappe.flags, "in_test", False), patch(
+        with self.enforce_only_for_checks(), patch(
             "frappe_assistant_core.api.admin_api.frappe.db.count",
             side_effect=audit_stat_counts,
         ), patch(
@@ -123,7 +123,7 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
         usage_stat_counts = [3, 1, 2, 3, 1, 2]  # connections total/today/week, audit total/today/week
 
         frappe.set_user("Administrator")
-        with patch.object(frappe.flags, "in_test", False), patch(
+        with self.enforce_only_for_checks(), patch(
             "frappe_assistant_core.api.assistant_api._authenticate_request",
             return_value="Administrator",
         ), patch(

--- a/frappe_assistant_core/tests/test_usage_statistics_permissions.py
+++ b/frappe_assistant_core/tests/test_usage_statistics_permissions.py
@@ -23,21 +23,6 @@ import frappe
 from frappe_assistant_core.tests.base_test import BaseAssistantTest
 
 
-def _strict_only_for(roles, message=False):
-    """frappe.only_for replacement that enforces checks during tests."""
-    if frappe.session.user == "Administrator":
-        return
-    if isinstance(roles, str):
-        roles = (roles,)
-    if set(roles).isdisjoint(frappe.get_roles()):
-        if not message:
-            raise frappe.PermissionError
-        frappe.throw(
-            f"This action is only allowed for {', '.join(roles)}",
-            frappe.PermissionError,
-        )
-
-
 class TestUsageStatisticsPermissions(BaseAssistantTest):
     """Ensure usage statistics are restricted to assistant admins."""
 
@@ -85,13 +70,10 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
 
         frappe.set_user(self.ASSISTANT_USER)
         frappe.clear_cache(user=self.ASSISTANT_USER)
-        original_only_for = frappe.only_for
-        frappe.only_for = _strict_only_for
-        try:
+
+        with patch.object(frappe.flags, "in_test", False):
             with self.assertRaises(frappe.PermissionError):
                 get_usage_statistics()
-        finally:
-            frappe.only_for = original_only_for
 
     def test_admin_usage_statistics_allowed_for_admin(self):
         """Administrator can access admin usage statistics."""
@@ -99,11 +81,12 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
 
         mock_plugin_manager = MagicMock()
         mock_plugin_manager.get_all_tools.return_value = {"sample_tool": object()}
+        audit_stat_counts = [3, 1, 2]  # audit log total, today, this week
 
         frappe.set_user("Administrator")
-        with patch(
+        with patch.object(frappe.flags, "in_test", False), patch(
             "frappe_assistant_core.api.admin_api.frappe.db.count",
-            side_effect=[3, 1, 2],
+            side_effect=audit_stat_counts,
         ), patch(
             "frappe_assistant_core.api.admin_api.frappe.db.get_list",
             return_value=[],
@@ -137,14 +120,15 @@ class TestUsageStatisticsPermissions(BaseAssistantTest):
 
         mock_plugin_manager = MagicMock()
         mock_plugin_manager.get_all_tools.return_value = {"sample_tool": object()}
+        usage_stat_counts = [3, 1, 2, 3, 1, 2]  # connections total/today/week, audit total/today/week
 
         frappe.set_user("Administrator")
-        with patch(
+        with patch.object(frappe.flags, "in_test", False), patch(
             "frappe_assistant_core.api.assistant_api._authenticate_request",
             return_value="Administrator",
         ), patch(
             "frappe_assistant_core.api.assistant_api.frappe.db.count",
-            side_effect=[3, 1, 2, 3, 1, 2],
+            side_effect=usage_stat_counts,
         ), patch(
             "frappe_assistant_core.api.assistant_api.frappe.db.get_list",
             return_value=[],

--- a/frappe_assistant_core/utils/permissions.py
+++ b/frappe_assistant_core/utils/permissions.py
@@ -19,6 +19,9 @@ import json
 import frappe
 from frappe import _, get_doc, has_permission
 
+ASSISTANT_ADMIN_ROLES = ("System Manager", "Assistant Admin")
+ASSISTANT_ACCESS_ROLES = ASSISTANT_ADMIN_ROLES + ("Assistant User",)
+
 
 def check_tool_permissions(tool_name: str, user: str) -> bool:
     """Check if the user has permissions to access the specified tool."""
@@ -51,20 +54,20 @@ def get_roles(user: str) -> list:
 
 
 def get_audit_permission_query_conditions(user=None):
-    """Permission query conditions for Assistant Audit Log"""
+    """Permission query conditions for Assistant Audit Log."""
     if not user:
         user = frappe.session.user
 
-    roles = frappe.get_roles(user)
+    user_roles = frappe.get_roles(user)
+    escaped_user = frappe.db.escape(user)
 
-    # System Manager, Assistant Admin, and Auditor can see all audit logs
-    if any(r in roles for r in ("System Manager", "Assistant Admin", "Auditor")):
+    # System Manager, Assistant Admin, and Auditor can see all audit logs.
+    if any(role in user_roles for role in ASSISTANT_ADMIN_ROLES + ("Auditor",)):
         return ""
 
-    # Assistant Users can only see their own audit logs
-    if "Assistant User" in roles:
-        # Escape via frappe.db.escape to avoid string-interpolation injection
-        return f"`tabAssistant Audit Log`.user = {frappe.db.escape(user)}"
+    # Assistant Users can only see their own audit logs.
+    if "Assistant User" in user_roles:
+        return f"`tabAssistant Audit Log`.user = {escaped_user}"
 
     # No access for others
     return "1=0"
@@ -76,9 +79,8 @@ def check_assistant_permission(user=None):
         user = frappe.session.user
 
     user_roles = frappe.get_roles(user)
-    assistant_roles = ["System Manager", "Assistant Admin", "Assistant User"]
 
-    return any(role in user_roles for role in assistant_roles)
+    return any(role in user_roles for role in ASSISTANT_ACCESS_ROLES)
 
 
 def check_assistant_admin_permission(user=None):
@@ -87,9 +89,8 @@ def check_assistant_admin_permission(user=None):
         user = frappe.session.user
 
     user_roles = frappe.get_roles(user)
-    admin_roles = ["System Manager", "Assistant Admin"]
 
-    return any(role in user_roles for role in admin_roles)
+    return any(role in user_roles for role in ASSISTANT_ADMIN_ROLES)
 
 
 def get_prompt_permission_query_conditions(user=None):

--- a/frappe_assistant_core/utils/permissions.py
+++ b/frappe_assistant_core/utils/permissions.py
@@ -81,6 +81,17 @@ def check_assistant_permission(user=None):
     return any(role in user_roles for role in assistant_roles)
 
 
+def check_assistant_admin_permission(user=None):
+    """Check if user has assistant admin access permission."""
+    if not user:
+        user = frappe.session.user
+
+    user_roles = frappe.get_roles(user)
+    admin_roles = ["System Manager", "Assistant Admin"]
+
+    return any(role in user_roles for role in admin_roles)
+
+
 def get_prompt_permission_query_conditions(user=None):
     """
     Permission query conditions for Prompt Template.


### PR DESCRIPTION
## Summary

* Restricts both usage statistics endpoints to Assistant Admin and System Manager so ordinary Assistant User accounts cannot access global assistant activitymetrics. 
* Adds regression tests to verify non-admin assistant users are denied while admins retain access.

  ## Type of Change
  - Bug fix
  - Security fix

  ## Related Issues

  Fixes #139

  ## Checklist

  - [x] I have targeted the develop branch (not main)
  - [x] My code follows the existing code style
  - [x] I have tested my changes locally (bench --site <site> run-tests --app frappe_assistant_core)
  - [x] I have run bench migrate and verified it works
  - [x] I have added/updated documentation if needed
  - [x] I have added migration patches if introducing new settings with defaults