### PR TITLE
Fix audit log false-success and enrich captured fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,20 @@ repos:
       - id: ruff-format
         name: "Run ruff formatter"
 
+  # Frappe semgrep rules — same configs the CI 'Linters' workflow uses
+  # (.github/workflows/linter.yml). Runs only on changed Python files.
+  # The wrapper script clones frappe/semgrep-rules into ~/.cache the first
+  # time and refreshes it weekly.
+  - repo: local
+    hooks:
+      - id: frappe-semgrep
+        name: "Run Frappe semgrep rules"
+        entry: scripts/run_frappe_semgrep.sh
+        language: python
+        additional_dependencies: ["semgrep==1.159.0"]
+        types: [python]
+        require_serial: true
+
   # Prettier disabled - no JavaScript/CSS files in this project
   # - repo: https://github.com/pre-commit/mirrors-prettier
   #   rev: v2.7.1

--- a/client_packages/claude-desktop/build.py
+++ b/client_packages/claude-desktop/build.py
@@ -19,6 +19,7 @@ def validate_manifest():
     print("🔍 Validating manifest.json...")
 
     try:
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bundled package manifest next to build.py, not user input
         with open("manifest.json") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:

--- a/client_packages/claude-desktop/server/frappe_assistant_stdio_bridge.py
+++ b/client_packages/claude-desktop/server/frappe_assistant_stdio_bridge.py
@@ -9,6 +9,7 @@ import os
 import queue
 import sys
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from typing import Any, Dict
 
@@ -32,9 +33,17 @@ class StdioMCPWrapper:
         # Remove trailing slash if present
         self.server_url = self.server_url.rstrip("/")
 
+        # One session id per bridge process, so all tool calls in a single
+        # Claude Desktop conversation share a correlation id in the audit log.
+        # Client id identifies which MCP client hit the server.
+        self.session_id = os.environ.get("FRAPPE_MCP_SESSION_ID") or str(uuid.uuid4())
+        self.client_id = os.environ.get("FRAPPE_MCP_CLIENT_ID") or "claude-desktop-stdio"
+
         self.headers = {
             "Authorization": f"token {self.api_key}:{self.api_secret}",
             "Content-Type": "application/json",
+            "Mcp-Session-Id": self.session_id,
+            "X-Assistant-Client-Id": self.client_id,
         }
 
         # Thread pool for handling concurrent requests

--- a/client_packages/claude-desktop/validate_manifest.py
+++ b/client_packages/claude-desktop/validate_manifest.py
@@ -20,6 +20,7 @@ def validate_manifest():
 
     # Load and parse JSON
     try:
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bundled package manifest next to this script, not user input
         with open("manifest.json") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:

--- a/frappe_assistant_core/api/assistant_api.py
+++ b/frappe_assistant_core/api/assistant_api.py
@@ -206,6 +206,7 @@ def _authenticate_request() -> Optional[str]:
                             return None
 
                         # Set user context for this request
+                        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user authenticated via API key:secret comparison above
                         frappe.set_user(str(user))
                         api_logger.debug(f"API key authentication successful: {user}")
                         return str(user)

--- a/frappe_assistant_core/api/fac_endpoint.py
+++ b/frappe_assistant_core/api/fac_endpoint.py
@@ -122,6 +122,7 @@ def _authenticate_mcp_request():
                 raise frappe.AuthenticationError("Token has expired")
 
             # Set the user session
+            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user resolved from validated, non-expired OAuth bearer token
             frappe.set_user(bearer_token.user)
             frappe.logger().info(f"OAuth token validated successfully for user: {bearer_token.user}")
             return bearer_token.user
@@ -188,6 +189,7 @@ def _authenticate_mcp_request():
 
                     if api_secret == decrypted_secret:
                         # Set user context for this request
+                        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user authenticated via API key:secret comparison above
                         frappe.set_user(str(user))
                         frappe.logger().info(f"API key authentication successful for user: {user}")
                         return str(user)

--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -27,6 +27,7 @@ import frappe
 from frappe.oauth import get_server_url
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — OpenID Connect Discovery 1.0 mandates unauthenticated access to this endpoint
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def openid_configuration():
     """
@@ -83,6 +84,7 @@ def openid_configuration():
         )
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 7517 JWKS endpoint is public by specification
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def jwks():
     """
@@ -95,6 +97,7 @@ def jwks():
     return {"keys": []}
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — MCP server discovery is unauthenticated by spec so clients can find the server
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def mcp_discovery():
     """
@@ -170,6 +173,7 @@ def _get_frappe_authorization_server_metadata():
         return metadata
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 8414 OAuth 2.0 Authorization Server Metadata requires unauthenticated access
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def authorization_server_metadata():
     """
@@ -233,6 +237,7 @@ def authorization_server_metadata():
     return metadata
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 9728 OAuth 2.0 Protected Resource Metadata requires unauthenticated access
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def protected_resource_metadata():
     """

--- a/frappe_assistant_core/api/oauth_registration.py
+++ b/frappe_assistant_core/api/oauth_registration.py
@@ -65,6 +65,7 @@ class OAuth2DynamicClientMetadata(BaseModel):
     jwks: dict | None = None
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 7591 Dynamic Client Registration is unauthenticated by design so new clients can onboard
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def register_client():
     """

--- a/frappe_assistant_core/api/oauth_token.py
+++ b/frappe_assistant_core/api/oauth_token.py
@@ -33,6 +33,7 @@ from frappe.oauth import generate_json_error_response
 from oauthlib.oauth2 import FatalClientError, OAuth2Error
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 6749 §3.2 OAuth token endpoint accepts unauthenticated public clients; credential validation happens inside the handler
 @frappe.whitelist(allow_guest=True)
 def get_token(*args, **kwargs):
     """

--- a/frappe_assistant_core/api/plugin_api.py
+++ b/frappe_assistant_core/api/plugin_api.py
@@ -18,6 +18,8 @@
 API endpoints for plugin management.
 """
 
+from typing import Any, Dict
+
 import frappe
 from frappe import _
 
@@ -75,7 +77,7 @@ def refresh_plugins():
 
 
 @frappe.whitelist(allow_guest=False)
-def get_plugin_info(plugin_name):
+def get_plugin_info(plugin_name: str) -> Dict[str, Any]:
     """
     Get detailed information about a specific plugin.
 

--- a/frappe_assistant_core/assistant_core/doctype/assistant_audit_log/assistant_audit_log.json
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_audit_log/assistant_audit_log.json
@@ -11,9 +11,11 @@
   "naming_series",
   "action",
   "tool_name",
+  "source_app",
   "user",
   "column_break_1",
   "status",
+  "error_type",
   "execution_time",
   "timestamp",
   "target_section",
@@ -21,11 +23,14 @@
   "target_name",
   "column_break_2",
   "client_id",
+  "session_id",
   "ip_address",
   "details_section",
   "input_data",
   "output_data",
-  "error_message"
+  "output_truncated",
+  "error_message",
+  "traceback"
  ],
  "fields": [
   {
@@ -53,6 +58,13 @@
    "read_only": 1
   },
   {
+   "fieldname": "source_app",
+   "fieldtype": "Data",
+   "label": "Source App",
+   "length": 120,
+   "read_only": 1
+  },
+  {
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -73,6 +85,14 @@
    "options": "Success\nError\nTimeout\nPermission Denied",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "error_type",
+   "fieldtype": "Data",
+   "label": "Error Type",
+   "length": 60,
+   "read_only": 1,
+   "description": "Exception class name or semantic category (e.g. PermissionError, ValidationError, ToolReportedError, ExecutionError, Timeout)"
   },
   {
    "fieldname": "execution_time",
@@ -115,7 +135,15 @@
    "fieldname": "client_id",
    "fieldtype": "Data",
    "label": "Client ID",
-   "read_only": 1
+   "read_only": 1,
+   "description": "MCP client identifier (e.g. claude-desktop) when available"
+  },
+  {
+   "fieldname": "session_id",
+   "fieldtype": "Data",
+   "label": "Session ID",
+   "read_only": 1,
+   "description": "Per-conversation correlation id. Rows sharing this id belong to the same MCP session."
   },
   {
    "fieldname": "ip_address",
@@ -144,10 +172,24 @@
    "read_only": 1
   },
   {
+   "fieldname": "output_truncated",
+   "fieldtype": "Check",
+   "label": "Output Truncated",
+   "read_only": 1,
+   "description": "Set when output_data exceeded the audit size limit and was clipped"
+  },
+  {
    "fieldname": "error_message",
    "fieldtype": "Text",
    "label": "Error Message",
    "read_only": 1
+  },
+  {
+   "fieldname": "traceback",
+   "fieldtype": "Long Text",
+   "label": "Traceback",
+   "read_only": 1,
+   "description": "Python traceback captured for unhandled exceptions"
   }
  ],
  "links": [],

--- a/frappe_assistant_core/assistant_core/doctype/assistant_audit_log/assistant_audit_log.py
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_audit_log/assistant_audit_log.py
@@ -21,7 +21,7 @@ from frappe.utils import now
 
 
 class AssistantAuditLog(Document):
-    """assistant Audit Log DocType controller"""
+    """Assistant Audit Log DocType controller"""
 
     def before_insert(self):
         """Set default values before inserting"""
@@ -57,11 +57,11 @@ def get_audit_statistics():
     today = frappe.utils.today()
 
     # Total actions today
-    total_today = frappe.db.count("assistant Audit Log", filters={"creation": [">=", today]})
+    total_today = frappe.db.count("Assistant Audit Log", filters={"creation": [">=", today]})
 
     # Success rate today
     successful_today = frappe.db.count(
-        "assistant Audit Log", filters={"creation": [">=", today], "status": "Success"}
+        "Assistant Audit Log", filters={"creation": [">=", today], "status": "Success"}
     )
 
     success_rate = (successful_today / total_today * 100) if total_today > 0 else 0
@@ -70,7 +70,7 @@ def get_audit_statistics():
     most_used_tools = frappe.db.sql(
         """
         SELECT tool_name, COUNT(*) as count
-        FROM `tabassistant Audit Log`
+        FROM `tabAssistant Audit Log`
         WHERE DATE(creation) = %s AND tool_name IS NOT NULL
         GROUP BY tool_name
         ORDER BY count DESC
@@ -85,7 +85,7 @@ def get_audit_statistics():
         frappe.db.sql(
             """
         SELECT AVG(execution_time) as avg_time
-        FROM `tabassistant Audit Log`
+        FROM `tabAssistant Audit Log`
         WHERE DATE(creation) = %s AND execution_time IS NOT NULL
     """,
             (today,),
@@ -102,9 +102,9 @@ def get_audit_statistics():
 
 
 def get_context(context):
-    context.title = _("assistant Audit Log")
+    context.title = _("Assistant Audit Log")
     context.docs = get_audit_logs()
 
 
 def get_audit_logs():
-    return frappe.get_all("assistant Audit Log", fields=["*"], order_by="creation desc")
+    return frappe.get_all("Assistant Audit Log", fields=["*"], order_by="creation desc")

--- a/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from typing import Any, Dict
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -52,7 +54,7 @@ class AssistantCoreSettings(Document):
             # Enable API with new settings
             self.enable_assistant_api()
 
-            frappe.msgprint("assistant MCP API restarted successfully")
+            frappe.msgprint(_("Assistant MCP API restarted successfully"))
 
         except Exception as e:
             frappe.log_error(f"Failed to restart assistant MCP API: {str(e)}")
@@ -297,7 +299,7 @@ class AssistantCoreSettings(Document):
             }
 
     @frappe.whitelist()
-    def toggle_plugin(self, plugin_name, action):
+    def toggle_plugin(self, plugin_name: str, action: str) -> Dict[str, Any]:
         """Enable or disable a plugin"""
         try:
             from frappe_assistant_core.utils.plugin_manager import PluginError, get_plugin_manager

--- a/frappe_assistant_core/assistant_core/server.py
+++ b/frappe_assistant_core/assistant_core/server.py
@@ -43,6 +43,7 @@ def get_frappe_port():
 
             if os.path.exists(sites_path) and os.path.isdir(sites_path):
                 if os.path.exists(config_file):
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
                     with open(config_file) as f:
                         common_config = json.load(f)
                         if "webserver_port" in common_config:

--- a/frappe_assistant_core/core/base_tool.py
+++ b/frappe_assistant_core/core/base_tool.py
@@ -20,6 +20,7 @@ Base class for all MCP tools with configuration and dependency management.
 
 import json
 import time
+import traceback
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -162,14 +163,28 @@ class BaseTool(ABC):
             # Calculate execution time
             execution_time = time.time() - start_time
 
-            # Prepare success response
-            response = {"success": True, "result": result, "execution_time": execution_time}
+            # Detect tool-reported failure: the tool returned normally but its
+            # payload is a dict with {"success": False}. Without this, every
+            # non-raising tool call was being logged as Success even when the
+            # tool explicitly signalled an error in its return value.
+            tool_reported_failure = isinstance(result, dict) and result.get("success") is False
 
-            # Log execution
-            self.log_execution(arguments, response, execution_time)
-
-            # Log success
-            self.logger.info(f"Successfully executed {self.name} in {execution_time:.3f}s")
+            if tool_reported_failure:
+                response = {
+                    "success": False,
+                    "result": result,
+                    "error": result.get("error") or "Tool reported failure",
+                    "error_type": "ToolReportedError",
+                    "execution_time": execution_time,
+                }
+                self.log_execution(arguments, response, execution_time, status="Error")
+                self.logger.info(
+                    f"{self.name} reported failure in {execution_time:.3f}s: {response['error']}"
+                )
+            else:
+                response = {"success": True, "result": result, "execution_time": execution_time}
+                self.log_execution(arguments, response, execution_time, status="Success")
+                self.logger.info(f"Successfully executed {self.name} in {execution_time:.3f}s")
 
             return response
 
@@ -182,10 +197,8 @@ class BaseTool(ABC):
                 "execution_time": execution_time,
             }
 
-            # Log execution
-            self.log_execution(arguments, response, execution_time)
+            self.log_execution(arguments, response, execution_time, status="Permission Denied")
 
-            # Log permission error
             frappe.log_error(title=_("Permission Error"), message=f"{self.name}: {str(e)}")
 
             return response
@@ -199,16 +212,36 @@ class BaseTool(ABC):
                 "execution_time": execution_time,
             }
 
-            # Log execution
-            self.log_execution(arguments, response, execution_time)
+            self.log_execution(arguments, response, execution_time, status="Error")
 
-            # Log validation error
             frappe.log_error(title=_("Validation Error"), message=f"{self.name}: {str(e)}")
+
+            return response
+
+        except TimeoutError as e:
+            execution_time = time.time() - start_time
+            response = {
+                "success": False,
+                "error": str(e),
+                "error_type": "Timeout",
+                "execution_time": execution_time,
+            }
+
+            self.log_execution(
+                arguments,
+                response,
+                execution_time,
+                status="Timeout",
+                traceback_str=traceback.format_exc(),
+            )
+
+            frappe.log_error(title=_("Tool Timeout"), message=f"{self.name}: {str(e)}")
 
             return response
 
         except Exception as e:
             execution_time = time.time() - start_time
+            tb = traceback.format_exc()
             response = {
                 "success": False,
                 "error": str(e),
@@ -216,25 +249,18 @@ class BaseTool(ABC):
                 "execution_time": execution_time,
             }
 
-            # Log execution
-            self.log_execution(arguments, response, execution_time)
-
-            # Enhanced error logging with more diagnostic information
-            import traceback
-
-            error_details = {
-                "tool_name": self.name,
-                "error_message": str(e),
-                "error_type": type(e).__name__,
-                "execution_time": execution_time,
-                "arguments": arguments,
-                "traceback": traceback.format_exc(),
-            }
+            self.log_execution(
+                arguments,
+                response,
+                execution_time,
+                status="Error",
+                traceback_str=tb,
+            )
 
             self.logger.error(f"Tool execution failed: {self.name} - {str(e)}", exc_info=True)
             frappe.log_error(
                 title=_("Tool Execution Error"),
-                message=f"Tool: {self.name}\nError: {str(e)}\nType: {type(e).__name__}\nArgs: {arguments}\n\nFull traceback:\n{traceback.format_exc()}",
+                message=f"Tool: {self.name}\nError: {str(e)}\nType: {type(e).__name__}\nArgs: {arguments}\n\nFull traceback:\n{tb}",
             )
 
             return response
@@ -331,7 +357,14 @@ class BaseTool(ABC):
         """Clear cached configuration to force reload"""
         self._config_cache = None
 
-    def log_execution(self, arguments: Dict[str, Any], result: Dict[str, Any], execution_time: float):
+    def log_execution(
+        self,
+        arguments: Dict[str, Any],
+        result: Dict[str, Any],
+        execution_time: float,
+        status: str = "Success",
+        traceback_str: Optional[str] = None,
+    ):
         """
         Log tool execution for audit purposes.
 
@@ -339,6 +372,9 @@ class BaseTool(ABC):
             arguments: Tool arguments (sensitive data will be sanitized)
             result: Execution result
             execution_time: Time taken in seconds
+            status: Audit-log status value — one of "Success", "Error",
+                "Timeout", "Permission Denied". Must match the DocType Select.
+            traceback_str: Full Python traceback on exception paths. None otherwise.
         """
         try:
             from frappe_assistant_core.utils.audit_trail import log_tool_execution
@@ -355,11 +391,13 @@ class BaseTool(ABC):
                 tool_name=self.name,
                 user=frappe.session.user,
                 arguments=self._sanitize_arguments(arguments),
-                success=result.get("success", False),
+                status=status,
                 execution_time=execution_time,
                 source_app=self.source_app,
-                error_message=result.get("error") if not result.get("success") else None,
-                output_data=sanitized_output,  # Direct tool output, not wrapper
+                error_message=result.get("error") if status != "Success" else None,
+                error_type=result.get("error_type"),
+                traceback_str=traceback_str,
+                output_data=sanitized_output,
             )
         except Exception as e:
             # Don't fail tool execution due to logging issues

--- a/frappe_assistant_core/mcp/server.py
+++ b/frappe_assistant_core/mcp/server.py
@@ -163,6 +163,11 @@ class MCPServer:
             )
             return self._error_response(response, None, -32700, f"Parse error: {str(e)}")
 
+        # Populate correlation ids on frappe.local so downstream audit logging
+        # can tag every tool execution with the MCP session and client. See
+        # _populate_correlation_ids for header/initialize param fallback order.
+        self._populate_correlation_ids(request, data)
+
         # Check if notification (no response needed)
         if self._is_notification(data):
             response.status_code = 202  # Accepted
@@ -225,6 +230,39 @@ class MCPServer:
             tool_dict: Dict with keys: name, description, inputSchema, fn, annotations
         """
         self._tool_registry[tool_dict["name"]] = tool_dict
+
+    def _populate_correlation_ids(self, request: Request, data: Dict):
+        """
+        Set `frappe.local.assistant_session_id` and `assistant_client_id`.
+
+        Resolution order for session id:
+            1. `Mcp-Session-Id` request header (MCP streamable HTTP transport)
+            2. `X-Assistant-Session-Id` request header (explicit override)
+            3. A freshly-generated UUID4 (per-request fallback)
+
+        Resolution order for client id:
+            1. `X-Assistant-Client-Id` request header
+            2. `clientInfo.name` from the `initialize` params when present
+            3. `None`
+        """
+        import uuid
+
+        import frappe
+
+        session_id = (
+            request.headers.get("Mcp-Session-Id")
+            or request.headers.get("X-Assistant-Session-Id")
+            or str(uuid.uuid4())
+        )
+
+        client_id = request.headers.get("X-Assistant-Client-Id")
+        if not client_id:
+            params = data.get("params") or {}
+            client_info = params.get("clientInfo") or {}
+            client_id = client_info.get("name")
+
+        frappe.local.assistant_session_id = session_id
+        frappe.local.assistant_client_id = client_id
 
     def _handle_initialize(self, params: Dict) -> Dict:
         """

--- a/frappe_assistant_core/plugins/core/tools/document_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/document_tools.py
@@ -312,10 +312,14 @@ class DocumentTools:
                     "user": frappe.session.user,
                     "user_roles": frappe.get_roles(),
                     "doctype_permissions": {
-                        "read": frappe.has_permission(doctype, "read"),
-                        "write": frappe.has_permission(doctype, "write"),
-                        "create": frappe.has_permission(doctype, "create"),
-                        "delete": frappe.has_permission(doctype, "delete"),
+                        # Reporting capabilities to the caller — not a security
+                        # boundary. Enforcement happens via the read check
+                        # earlier in list_documents; these booleans just tell
+                        # the LLM what actions it could take next.
+                        "read": frappe.has_permission(doctype, "read", throw=False),
+                        "write": frappe.has_permission(doctype, "write", throw=False),
+                        "create": frappe.has_permission(doctype, "create", throw=False),
+                        "delete": frappe.has_permission(doctype, "delete", throw=False),
                     },
                     "query_attempts": len(error_details) + 1,
                     "final_fields_used": safe_fields,

--- a/frappe_assistant_core/plugins/core/tools/metadata_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/metadata_tools.py
@@ -184,14 +184,16 @@ class MetadataTools:
 
             check_user = user or frappe.session.user
 
+            # Reporting capabilities — not a security boundary. throw=False
+            # keeps this explicit and silences the unchecked-permission rule.
             permissions = {
-                "read": frappe.has_permission(doctype, "read", user=check_user),
-                "write": frappe.has_permission(doctype, "write", user=check_user),
-                "create": frappe.has_permission(doctype, "create", user=check_user),
-                "delete": frappe.has_permission(doctype, "delete", user=check_user),
-                "submit": frappe.has_permission(doctype, "submit", user=check_user),
-                "cancel": frappe.has_permission(doctype, "cancel", user=check_user),
-                "amend": frappe.has_permission(doctype, "amend", user=check_user),
+                "read": frappe.has_permission(doctype, "read", user=check_user, throw=False),
+                "write": frappe.has_permission(doctype, "write", user=check_user, throw=False),
+                "create": frappe.has_permission(doctype, "create", user=check_user, throw=False),
+                "delete": frappe.has_permission(doctype, "delete", user=check_user, throw=False),
+                "submit": frappe.has_permission(doctype, "submit", user=check_user, throw=False),
+                "cancel": frappe.has_permission(doctype, "cancel", user=check_user, throw=False),
+                "amend": frappe.has_permission(doctype, "amend", user=check_user, throw=False),
             }
 
             # Get user roles

--- a/frappe_assistant_core/plugins/core/tools/report_requirements.py
+++ b/frappe_assistant_core/plugins/core/tools/report_requirements.py
@@ -313,7 +313,7 @@ class ReportRequirements(BaseTool):
                 )
 
                 if os.path.exists(js_path):
-                    # Read JavaScript file
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — path built from frappe.get_app_path + report metadata, not user input
                     with open(js_path, encoding="utf-8") as f:
                         js_content = f.read()
 

--- a/frappe_assistant_core/plugins/core/tools/report_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/report_tools.py
@@ -738,7 +738,7 @@ class ReportTools:
                 )
 
                 if os.path.exists(js_path):
-                    # Read and parse the JavaScript file
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — path built from frappe.get_app_path + report metadata, not user input
                     with open(js_path, encoding="utf-8") as f:
                         js_content = f.read()
 

--- a/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
+++ b/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
@@ -295,6 +295,7 @@ class ExtractFileContent(BaseTool):
             # 1. Try local filesystem
             file_path = self._get_file_path(file_doc)
             if file_path and os.path.exists(file_path):
+                # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — _get_file_path scopes to /private or /files under the site directory via frappe.get_site_path
                 with open(file_path, "rb") as f:
                     return f.read()
 

--- a/frappe_assistant_core/plugins/data_science/tools/run_database_query.py
+++ b/frappe_assistant_core/plugins/data_science/tools/run_database_query.py
@@ -290,7 +290,11 @@ class QueryAndAnalyse(BaseTool):
         return suggestions
 
     def _get_schema_info(self, query: str) -> Dict[str, Any]:
-        """Extract schema information for tables used in query"""
+        """Extract schema information for tables used in query.
+
+        Uses `frappe.db.get_table_columns_description` so the table name
+        never appears interpolated into raw SQL from this module.
+        """
         try:
             # Extract table names from query (basic implementation)
             tables = re.findall(r"FROM\s+`?(\w+)`?|JOIN\s+`?(\w+)`?", query, re.IGNORECASE)
@@ -301,8 +305,7 @@ class QueryAndAnalyse(BaseTool):
             schema_info = {}
             for table in table_names:
                 try:
-                    # Get column information
-                    columns = frappe.db.sql(f"DESCRIBE `{table}`", as_dict=True)
+                    columns = frappe.db.get_table_columns_description(table)
                     schema_info[table] = {"columns": columns, "total_columns": len(columns)}
                 except Exception as e:
                     schema_info[table] = {"error": f"Could not retrieve schema: {str(e)}"}

--- a/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
+++ b/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
@@ -25,6 +25,7 @@ from typing import Any, Dict
 
 import frappe
 from frappe import _
+from frappe.query_builder import Order
 
 from frappe_assistant_core.core.base_tool import BaseTool
 
@@ -800,7 +801,13 @@ PRE-LOADED: pd (pandas), np (numpy), plt (matplotlib), sns (seaborn), frappe, ma
         return "\n".join(cleaned_lines)
 
     def _fetch_data_from_query(self, data_query: Dict[str, Any]) -> list:
-        """Fetch data from Frappe based on query parameters"""
+        """Fetch data from Frappe based on query parameters.
+
+        Uses the Query Builder (`frappe.qb`) so that field names and filter
+        keys — which can come from LLM-generated input — cannot be used to
+        inject SQL. Unknown field names surface as a validation error via
+        `frappe.get_meta`, not as a malformed query reaching the DB.
+        """
         doctype = data_query.get("doctype")
         fields = data_query.get("fields", ["name"])
         filters = data_query.get("filters", {})
@@ -809,57 +816,57 @@ PRE-LOADED: pd (pandas), np (numpy), plt (matplotlib), sns (seaborn), frappe, ma
         if not doctype:
             raise ValueError("DocType is required for data query")
 
-        # Check permission
         if not frappe.has_permission(doctype, "read"):
             raise frappe.PermissionError(f"No permission to read {doctype}")
 
-        # Use raw SQL to avoid frappe._dict objects that cause __array_struct__ issues
-        try:
-            # Build SQL query manually to get clean data
-            field_list = ", ".join([f"`{field}`" for field in fields])
-            table_name = f"tab{doctype}"
+        # Validate doctype up-front so a bad value triggers a clean error
+        # instead of a SQL failure deeper down.
+        meta = frappe.get_meta(doctype)
 
-            # Build WHERE clause from filters
-            where_conditions = []
-            values = []
+        # Validate every field name and filter key against the DocType meta.
+        # `name`, `creation`, `modified`, `modified_by`, `owner`, `docstatus`,
+        # `idx`, `parent`, `parentfield`, `parenttype` are always valid.
+        standard_fields = {
+            "name",
+            "creation",
+            "modified",
+            "modified_by",
+            "owner",
+            "docstatus",
+            "idx",
+            "parent",
+            "parentfield",
+            "parenttype",
+        }
 
-            for key, value in filters.items():
-                if isinstance(value, (list, tuple)):
-                    placeholders = ", ".join(["%s"] * len(value))
-                    where_conditions.append(f"`{key}` IN ({placeholders})")
-                    values.extend(value)
-                elif value is None:
-                    where_conditions.append(f"`{key}` IS NULL")
-                else:
-                    where_conditions.append(f"`{key}` = %s")
-                    values.append(value)
+        def _ensure_field(field_name: str) -> None:
+            if field_name not in standard_fields and not meta.has_field(field_name):
+                raise ValueError(f"Unknown field '{field_name}' on DocType '{doctype}'")
 
-            where_clause = ""
-            if where_conditions:
-                where_clause = "WHERE " + " AND ".join(where_conditions)
+        for field in fields:
+            _ensure_field(field)
+        for key in filters:
+            _ensure_field(key)
 
-            query = f"""
-                SELECT {field_list}
-                FROM `{table_name}`
-                {where_clause}
-                ORDER BY creation DESC
-                LIMIT {limit}
-            """
+        table = frappe.qb.DocType(doctype)
+        query = frappe.qb.from_(table).select(*[table[f] for f in fields])
 
-            # Execute raw SQL to get clean data without frappe._dict objects
-            result = frappe.db.sql(query, values, as_dict=True)
+        for key, value in filters.items():
+            column = table[key]
+            if isinstance(value, (list, tuple)):
+                query = query.where(column.isin(list(value)))
+            elif value is None:
+                query = query.where(column.isnull())
+            else:
+                query = query.where(column == value)
 
-            # Convert to plain Python dicts to avoid array interface issues
-            return [dict(row) for row in result]
+        query = query.orderby(table.creation, order=Order.desc).limit(limit)
 
-        except Exception as e:
-            # Fallback to get_all with conversion if SQL approach fails
-            frappe.log_error(f"SQL data query failed: {str(e)}")
+        rows = query.run(as_dict=True)
 
-            raw_data = frappe.get_all(doctype, fields=fields, filters=filters, limit=limit)
-
-            # Convert frappe._dict objects to plain dicts
-            return [dict(row) for row in raw_data]
+        # Strip frappe._dict wrappers so numpy/pandas interop downstream
+        # doesn't trip on the __array_struct__ attribute.
+        return [dict(row) for row in rows]
 
     def _setup_execution_environment(self) -> Dict[str, Any]:
         """Legacy method - use _setup_secure_execution_environment instead"""

--- a/frappe_assistant_core/plugins/visualization/plugin.py
+++ b/frappe_assistant_core/plugins/visualization/plugin.py
@@ -244,6 +244,7 @@ class VisualizationPlugin(BasePlugin):
             for template_file in template_files:
                 template_path = os.path.join(template_dir, template_file)
                 if os.path.exists(template_path):
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
                     with open(template_path) as f:
                         template_data = json.load(f)
                         loaded_templates.append(template_data["name"])

--- a/frappe_assistant_core/plugins/visualization/plugin_registry.py
+++ b/frappe_assistant_core/plugins/visualization/plugin_registry.py
@@ -272,6 +272,7 @@ class VisualizationPlugin(BasePlugin):
             for template_file in template_files:
                 template_path = os.path.join(template_dir, template_file)
                 if os.path.exists(template_path):
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
                     with open(template_path) as f:
                         template_data = json.load(f)
                         loaded_templates.append(template_data["name"])

--- a/frappe_assistant_core/services/config_reader.py
+++ b/frappe_assistant_core/services/config_reader.py
@@ -87,6 +87,7 @@ def get_fallback_redis_config() -> Dict[str, Any]:
 
         for config_path in config_paths:
             try:
+                # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — paths built from bench cwd and fixed config filenames, not user input
                 with open(config_path) as f:
                     for line in f:
                         line = line.strip()

--- a/frappe_assistant_core/tests/base_test.py
+++ b/frappe_assistant_core/tests/base_test.py
@@ -37,6 +37,7 @@ class BaseAssistantTest(unittest.TestCase):
 
         # Set default user
         if not hasattr(frappe, "session") or not frappe.session.user:
+            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — test bootstrap; tests run in isolated transaction
             frappe.set_user("Administrator")
 
     def setUp(self):
@@ -46,6 +47,7 @@ class BaseAssistantTest(unittest.TestCase):
 
         # Set test user
         self.test_user = "Administrator"
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — test bootstrap; tests run in isolated transaction
         frappe.set_user(self.test_user)
 
         # Ensure plugins are enabled for testing
@@ -146,7 +148,7 @@ class BaseAssistantTest(unittest.TestCase):
 
             for doctype in test_doctypes:
                 if frappe.db.exists("DocType", doctype):
-                    frappe.db.sql(f"DELETE FROM `tab{doctype}` WHERE name LIKE 'TEST_%'")
+                    frappe.db.delete(doctype, {"name": ("like", "TEST_%")})
 
             frappe.db.commit()
         except Exception:

--- a/frappe_assistant_core/tests/base_test.py
+++ b/frappe_assistant_core/tests/base_test.py
@@ -72,23 +72,28 @@ class BaseAssistantTest(unittest.TestCase):
         """
         Execute a tool via registry expecting tool-level failure.
         Returns the tool result for further assertions.
+
+        Works for both failure modes:
+        - Tool raised an exception — registry wrapper has success=False and
+          error_type set; no inner "result" dict.
+        - Tool returned {"success": False, ...} — registry wrapper now also
+          has success=False (since the audit-log accuracy fix) with
+          error_type="ToolReportedError" and the tool's dict under "result".
         """
         registry_result = registry.execute_tool(tool_name, arguments)
 
-        # Registry execution should succeed even if tool fails
-        self.assertTrue(
-            registry_result.get("success"), f"Registry execution failed: {registry_result.get('error')}"
-        )
-
-        # Get tool result and verify it failed
-        tool_result = registry_result.get("result", {})
         self.assertFalse(
-            tool_result.get("success"), f"Tool execution should have failed but succeeded: {tool_result}"
+            registry_result.get("success"),
+            f"Tool execution should have failed but succeeded: {registry_result}",
         )
 
-        # Check error message if provided
+        # Prefer the inner tool dict when present (ToolReportedError path);
+        # fall back to the wrapper itself for exception-raising tools.
+        tool_result = registry_result.get("result") or registry_result
+
         if expected_error_text:
-            self.assertIn(expected_error_text, tool_result.get("error", ""))
+            error_text = tool_result.get("error") or registry_result.get("error") or ""
+            self.assertIn(expected_error_text, error_text)
 
         return tool_result
 

--- a/frappe_assistant_core/tests/test_audit_log.py
+++ b/frappe_assistant_core/tests/test_audit_log.py
@@ -70,7 +70,7 @@ def _fetch_latest_audit_row(tool_name: str) -> Dict[str, Any]:
 
 
 def _delete_test_rows(tool_name: str):
-    frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+    frappe.db.delete("Assistant Audit Log", {"tool_name": tool_name})
 
 
 class TestAuditLogStatusClassification(BaseAssistantTest):

--- a/frappe_assistant_core/tests/test_audit_log.py
+++ b/frappe_assistant_core/tests/test_audit_log.py
@@ -69,18 +69,20 @@ def _fetch_latest_audit_row(tool_name: str) -> Dict[str, Any]:
     return rows[0]
 
 
+def _delete_test_rows(tool_name: str):
+    frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+
+
 class TestAuditLogStatusClassification(BaseAssistantTest):
     """A tool call's audit status must reflect what actually happened."""
 
     def setUp(self):
         super().setUp()
-        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (_TEST_TOOL_NAME,))
-        frappe.db.commit()
+        _delete_test_rows(_TEST_TOOL_NAME)
 
     def test_successful_execution_logs_success(self):
-        tool = _ToolBase(executor=lambda args: {"items": [1, 2, 3]})
+        tool = _ToolBase(executor=lambda arguments: {"items": [1, 2, 3]})
         response = tool._safe_execute({})
-        frappe.db.commit()
 
         self.assertTrue(response["success"])
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
@@ -92,12 +94,11 @@ class TestAuditLogStatusClassification(BaseAssistantTest):
         """A tool returning {"success": False, ...} was previously logged as
         Success. It must now be logged as Error with ToolReportedError type."""
 
-        def executor(args):
+        def executor(arguments):
             return {"success": False, "error": "file not found"}
 
         tool = _ToolBase(executor=executor)
         response = tool._safe_execute({})
-        frappe.db.commit()
 
         self.assertFalse(response["success"])
         self.assertEqual(response["error_type"], "ToolReportedError")
@@ -108,24 +109,22 @@ class TestAuditLogStatusClassification(BaseAssistantTest):
         self.assertIn("file not found", row["error_message"] or "")
 
     def test_permission_error_logs_permission_denied(self):
-        def executor(args):
+        def executor(arguments):
             raise frappe.PermissionError("no access")
 
         tool = _ToolBase(executor=executor)
         tool._safe_execute({})
-        frappe.db.commit()
 
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
         self.assertEqual(row["status"], "Permission Denied")
         self.assertEqual(row["error_type"], "PermissionError")
 
     def test_uncaught_exception_logs_error_with_traceback(self):
-        def executor(args):
+        def executor(arguments):
             raise RuntimeError("boom")
 
         tool = _ToolBase(executor=executor)
         tool._safe_execute({})
-        frappe.db.commit()
 
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
         self.assertEqual(row["status"], "Error")
@@ -134,12 +133,11 @@ class TestAuditLogStatusClassification(BaseAssistantTest):
         self.assertIn("RuntimeError", row["traceback"])
 
     def test_timeout_error_logs_timeout(self):
-        def executor(args):
+        def executor(arguments):
             raise TimeoutError("tool timed out")
 
         tool = _ToolBase(executor=executor)
         tool._safe_execute({})
-        frappe.db.commit()
 
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
         self.assertEqual(row["status"], "Timeout")
@@ -151,13 +149,11 @@ class TestAuditLogFieldCapture(BaseAssistantTest):
 
     def setUp(self):
         super().setUp()
-        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (_TEST_TOOL_NAME,))
-        frappe.db.commit()
+        _delete_test_rows(_TEST_TOOL_NAME)
 
     def test_source_app_is_written(self):
-        tool = _ToolBase(executor=lambda args: {"ok": True})
+        tool = _ToolBase(executor=lambda arguments: {"ok": True})
         tool._safe_execute({})
-        frappe.db.commit()
 
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
         self.assertEqual(row["source_app"], "frappe_assistant_core")
@@ -166,9 +162,8 @@ class TestAuditLogFieldCapture(BaseAssistantTest):
         frappe.local.assistant_session_id = "session-abc"
         frappe.local.assistant_client_id = "claude-desktop-test"
         try:
-            tool = _ToolBase(executor=lambda args: {"ok": True})
+            tool = _ToolBase(executor=lambda arguments: {"ok": True})
             tool._safe_execute({})
-            frappe.db.commit()
 
             row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
             self.assertEqual(row["session_id"], "session-abc")
@@ -184,9 +179,8 @@ class TestAuditLogFieldCapture(BaseAssistantTest):
         # 50KB sink cap. Many small items under an unrecognised key works.
         big_payload = {f"item_{i}": "padding" * 200 for i in range(60)}
 
-        tool = _ToolBase(executor=lambda args: big_payload)
+        tool = _ToolBase(executor=lambda arguments: big_payload)
         tool._safe_execute({})
-        frappe.db.commit()
 
         row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
         self.assertEqual(row["output_truncated"], 1)
@@ -199,7 +193,7 @@ class TestAuditSinkSanitization(BaseAssistantTest):
         from frappe_assistant_core.utils.audit_trail import log_tool_execution
 
         tool_name = "test_audit_sanitization"
-        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+        _delete_test_rows(tool_name)
 
         log_tool_execution(
             tool_name=tool_name,
@@ -209,7 +203,6 @@ class TestAuditSinkSanitization(BaseAssistantTest):
             execution_time=0.01,
             source_app="frappe_assistant_core",
         )
-        frappe.db.commit()
 
         row = frappe.get_all(
             "Assistant Audit Log",
@@ -225,7 +218,7 @@ class TestAuditSinkSanitization(BaseAssistantTest):
         from frappe_assistant_core.utils.audit_trail import log_tool_execution
 
         tool_name = "test_audit_invalid_status"
-        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+        _delete_test_rows(tool_name)
 
         log_tool_execution(
             tool_name=tool_name,
@@ -235,7 +228,6 @@ class TestAuditSinkSanitization(BaseAssistantTest):
             execution_time=0.0,
             source_app="frappe_assistant_core",
         )
-        frappe.db.commit()
 
         row = frappe.get_all(
             "Assistant Audit Log",

--- a/frappe_assistant_core/tests/test_audit_log.py
+++ b/frappe_assistant_core/tests/test_audit_log.py
@@ -1,0 +1,247 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for Assistant Audit Log status classification and field capture.
+
+These tests exercise BaseTool._safe_execute directly via a minimal in-memory
+tool subclass, so they do not depend on any specific plugin being loaded.
+"""
+
+from typing import Any, Dict
+
+import frappe
+
+from frappe_assistant_core.core.base_tool import BaseTool
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+_TEST_TOOL_NAME = "test_audit_tool"
+
+
+class _ToolBase(BaseTool):
+    """Minimal concrete BaseTool used only in these tests."""
+
+    def __init__(self, executor=None):
+        super().__init__()
+        self.name = _TEST_TOOL_NAME
+        self.description = "Test tool"
+        self.inputSchema = {"type": "object", "properties": {}}
+        self.requires_permission = None  # skip the DocType permission check
+        self.source_app = "frappe_assistant_core"
+        self._executor = executor
+
+    def execute(self, arguments: Dict[str, Any]) -> Any:
+        return self._executor(arguments)
+
+
+def _fetch_latest_audit_row(tool_name: str) -> Dict[str, Any]:
+    rows = frappe.get_all(
+        "Assistant Audit Log",
+        filters={"tool_name": tool_name},
+        fields=[
+            "name",
+            "status",
+            "error_type",
+            "error_message",
+            "traceback",
+            "source_app",
+            "session_id",
+            "client_id",
+            "output_truncated",
+        ],
+        order_by="creation desc",
+        limit=1,
+    )
+    assert rows, f"No audit row found for tool {tool_name}"
+    return rows[0]
+
+
+class TestAuditLogStatusClassification(BaseAssistantTest):
+    """A tool call's audit status must reflect what actually happened."""
+
+    def setUp(self):
+        super().setUp()
+        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (_TEST_TOOL_NAME,))
+        frappe.db.commit()
+
+    def test_successful_execution_logs_success(self):
+        tool = _ToolBase(executor=lambda args: {"items": [1, 2, 3]})
+        response = tool._safe_execute({})
+        frappe.db.commit()
+
+        self.assertTrue(response["success"])
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["status"], "Success")
+        self.assertIsNone(row["error_type"])
+        self.assertIsNone(row["error_message"])
+
+    def test_tool_reported_failure_logs_error(self):
+        """A tool returning {"success": False, ...} was previously logged as
+        Success. It must now be logged as Error with ToolReportedError type."""
+
+        def executor(args):
+            return {"success": False, "error": "file not found"}
+
+        tool = _ToolBase(executor=executor)
+        response = tool._safe_execute({})
+        frappe.db.commit()
+
+        self.assertFalse(response["success"])
+        self.assertEqual(response["error_type"], "ToolReportedError")
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["status"], "Error")
+        self.assertEqual(row["error_type"], "ToolReportedError")
+        self.assertIn("file not found", row["error_message"] or "")
+
+    def test_permission_error_logs_permission_denied(self):
+        def executor(args):
+            raise frappe.PermissionError("no access")
+
+        tool = _ToolBase(executor=executor)
+        tool._safe_execute({})
+        frappe.db.commit()
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["status"], "Permission Denied")
+        self.assertEqual(row["error_type"], "PermissionError")
+
+    def test_uncaught_exception_logs_error_with_traceback(self):
+        def executor(args):
+            raise RuntimeError("boom")
+
+        tool = _ToolBase(executor=executor)
+        tool._safe_execute({})
+        frappe.db.commit()
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["status"], "Error")
+        self.assertEqual(row["error_type"], "ExecutionError")
+        self.assertTrue(row["traceback"], "traceback must be captured on exception path")
+        self.assertIn("RuntimeError", row["traceback"])
+
+    def test_timeout_error_logs_timeout(self):
+        def executor(args):
+            raise TimeoutError("tool timed out")
+
+        tool = _ToolBase(executor=executor)
+        tool._safe_execute({})
+        frappe.db.commit()
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["status"], "Timeout")
+        self.assertEqual(row["error_type"], "Timeout")
+
+
+class TestAuditLogFieldCapture(BaseAssistantTest):
+    """New audit columns must actually be populated end-to-end."""
+
+    def setUp(self):
+        super().setUp()
+        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (_TEST_TOOL_NAME,))
+        frappe.db.commit()
+
+    def test_source_app_is_written(self):
+        tool = _ToolBase(executor=lambda args: {"ok": True})
+        tool._safe_execute({})
+        frappe.db.commit()
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["source_app"], "frappe_assistant_core")
+
+    def test_session_and_client_ids_from_frappe_local(self):
+        frappe.local.assistant_session_id = "session-abc"
+        frappe.local.assistant_client_id = "claude-desktop-test"
+        try:
+            tool = _ToolBase(executor=lambda args: {"ok": True})
+            tool._safe_execute({})
+            frappe.db.commit()
+
+            row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+            self.assertEqual(row["session_id"], "session-abc")
+            self.assertEqual(row["client_id"], "claude-desktop-test")
+        finally:
+            # Don't bleed state into other tests
+            frappe.local.assistant_session_id = None
+            frappe.local.assistant_client_id = None
+
+    def test_large_output_is_truncated_and_flagged(self):
+        # BaseTool._sanitize_data clips long values under common keys, so
+        # build a payload that survives sanitization but still exceeds the
+        # 50KB sink cap. Many small items under an unrecognised key works.
+        big_payload = {f"item_{i}": "padding" * 200 for i in range(60)}
+
+        tool = _ToolBase(executor=lambda args: big_payload)
+        tool._safe_execute({})
+        frappe.db.commit()
+
+        row = _fetch_latest_audit_row(_TEST_TOOL_NAME)
+        self.assertEqual(row["output_truncated"], 1)
+
+
+class TestAuditSinkSanitization(BaseAssistantTest):
+    """The sink defensively redacts sensitive keys even if the caller forgot."""
+
+    def test_sink_redacts_sensitive_keys(self):
+        from frappe_assistant_core.utils.audit_trail import log_tool_execution
+
+        tool_name = "test_audit_sanitization"
+        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+
+        log_tool_execution(
+            tool_name=tool_name,
+            user=frappe.session.user,
+            arguments={"password": "hunter2", "doctype": "ToDo"},
+            status="Success",
+            execution_time=0.01,
+            source_app="frappe_assistant_core",
+        )
+        frappe.db.commit()
+
+        row = frappe.get_all(
+            "Assistant Audit Log",
+            filters={"tool_name": tool_name},
+            fields=["input_data"],
+            order_by="creation desc",
+            limit=1,
+        )[0]
+        self.assertIn("REDACTED", row["input_data"])
+        self.assertNotIn("hunter2", row["input_data"])
+
+    def test_invalid_status_is_coerced_to_error(self):
+        from frappe_assistant_core.utils.audit_trail import log_tool_execution
+
+        tool_name = "test_audit_invalid_status"
+        frappe.db.sql("DELETE FROM `tabAssistant Audit Log` WHERE tool_name = %s", (tool_name,))
+
+        log_tool_execution(
+            tool_name=tool_name,
+            user=frappe.session.user,
+            arguments={},
+            status="Failed",  # legacy value, not in the Select enum
+            execution_time=0.0,
+            source_app="frappe_assistant_core",
+        )
+        frappe.db.commit()
+
+        row = frappe.get_all(
+            "Assistant Audit Log",
+            filters={"tool_name": tool_name},
+            fields=["status"],
+            order_by="creation desc",
+            limit=1,
+        )[0]
+        self.assertEqual(row["status"], "Error")

--- a/frappe_assistant_core/utils/audit_trail.py
+++ b/frappe_assistant_core/utils/audit_trail.py
@@ -18,8 +18,42 @@ import json
 from typing import Any, Dict, Optional
 
 import frappe
-from frappe import _
 from frappe.utils import now
+
+# Allowed values for Assistant Audit Log `status` — must match the DocType Select.
+AUDIT_STATUS_SUCCESS = "Success"
+AUDIT_STATUS_ERROR = "Error"
+AUDIT_STATUS_TIMEOUT = "Timeout"
+AUDIT_STATUS_PERMISSION_DENIED = "Permission Denied"
+_VALID_STATUSES = {
+    AUDIT_STATUS_SUCCESS,
+    AUDIT_STATUS_ERROR,
+    AUDIT_STATUS_TIMEOUT,
+    AUDIT_STATUS_PERMISSION_DENIED,
+}
+
+# Output data is stored as JSON text in a Code field; cap to keep audit rows
+# from bloating when a tool returns a large payload.
+_OUTPUT_DATA_MAX_BYTES = 50_000
+
+# Keys that should never appear in audit logs in cleartext. Matched
+# case-insensitively on substring, same heuristic as BaseTool._sanitize_arguments.
+_SENSITIVE_KEY_SUBSTRINGS = ("password", "api_key", "secret", "token", "auth")
+
+
+def _sanitize_arguments(arguments: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Defensive sanitization at the audit sink — callers are expected to
+    sanitize too, but this ensures secrets never land in the table even
+    when a non-BaseTool call site forgets."""
+    if not isinstance(arguments, dict):
+        return arguments
+    sanitized: Dict[str, Any] = {}
+    for key, value in arguments.items():
+        if any(sub in key.lower() for sub in _SENSITIVE_KEY_SUBSTRINGS):
+            sanitized[key] = "***REDACTED***"
+        else:
+            sanitized[key] = value
+    return sanitized
 
 
 def log_document_change(doc, method):
@@ -105,12 +139,14 @@ def should_log_document(doctype):
 def log_tool_execution(
     tool_name: str,
     user: str,
-    arguments: Dict[str, Any],
-    success: bool,
+    arguments: Optional[Dict[str, Any]],
+    status: str,
     execution_time: float,
-    source_app: str,
+    source_app: Optional[str] = None,
     error_message: Optional[str] = None,
-    output_data: Optional[Dict[str, Any]] = None,
+    error_type: Optional[str] = None,
+    traceback_str: Optional[str] = None,
+    output_data: Optional[Any] = None,
 ):
     """
     Log tool execution for comprehensive audit trail.
@@ -118,48 +154,66 @@ def log_tool_execution(
     Args:
         tool_name: Name of the executed tool
         user: User who executed the tool
-        arguments: Tool arguments (sensitive data should be pre-sanitized)
-        success: Whether execution was successful
+        arguments: Tool arguments (sensitive data should be pre-sanitized; the
+            sink re-sanitizes defensively)
+        status: One of "Success", "Error", "Timeout", "Permission Denied".
+            Unknown values are coerced to "Error" with a warning.
         execution_time: Time taken in seconds
         source_app: App that provides the tool
         error_message: Error message if execution failed
+        error_type: Exception class name or semantic category (e.g.
+            "PermissionError", "ValidationError", "ToolReportedError")
+        traceback_str: Full Python traceback (exception paths only)
         output_data: Tool output data for audit trail
     """
     try:
-        # Extract target information from arguments
+        if status not in _VALID_STATUSES:
+            frappe.logger("audit_trail").warning(
+                f"log_tool_execution: invalid status {status!r} for tool {tool_name}; coercing to 'Error'"
+            )
+            status = AUDIT_STATUS_ERROR
+
+        sanitized_arguments = _sanitize_arguments(arguments)
+
+        # Extract target information from arguments (after sanitization so we
+        # can't leak secrets via target fields either)
         target_doctype = None
         target_name = None
+        if isinstance(sanitized_arguments, dict):
+            target_doctype = sanitized_arguments.get("doctype")
+            target_name = sanitized_arguments.get("name")
 
-        if arguments and isinstance(arguments, dict):
-            # For tools that work with specific documents
-            target_doctype = arguments.get("doctype")
-            target_name = arguments.get("name")
+        # Serialize output for storage, clamp oversized payloads
+        output_data_str, output_truncated = _serialize_for_audit(output_data)
 
-        # Use tool name directly as action (since action field is now Data type)
-        action = tool_name
-
-        # Serialize output data for storage
-        try:
-            output_data_str = json.dumps(output_data, default=str) if output_data else None
-        except (TypeError, ValueError):
-            # Fallback: convert to string and truncate for large data
-            output_data_str = str(output_data)[:2000]
+        input_data_str = None
+        if sanitized_arguments is not None:
+            try:
+                input_data_str = json.dumps(sanitized_arguments, default=str)
+            except (TypeError, ValueError):
+                input_data_str = str(sanitized_arguments)[:_OUTPUT_DATA_MAX_BYTES]
 
         audit_doc = frappe.get_doc(
             {
                 "doctype": "Assistant Audit Log",
-                "action": action,  # Now uses tool name directly
+                "action": tool_name,
                 "tool_name": tool_name,
                 "user": user,
-                "status": "Success" if success else "Failed",
+                "status": status,
                 "timestamp": now(),
                 "execution_time": execution_time,
-                "target_doctype": target_doctype,  # Populated from arguments
-                "target_name": target_name,  # Populated from arguments
+                "target_doctype": target_doctype,
+                "target_name": target_name,
+                "client_id": getattr(frappe.local, "assistant_client_id", None),
+                "session_id": getattr(frappe.local, "assistant_session_id", None),
+                "source_app": source_app,
                 "ip_address": getattr(frappe.local, "request_ip", None),
-                "input_data": json.dumps(arguments) if arguments else None,
-                "output_data": output_data_str,  # Now includes output
+                "input_data": input_data_str,
+                "output_data": output_data_str,
+                "output_truncated": 1 if output_truncated else 0,
                 "error_message": error_message,
+                "error_type": error_type,
+                "traceback": traceback_str,
             }
         )
 
@@ -168,6 +222,19 @@ def log_tool_execution(
     except Exception as e:
         # Don't fail tool execution due to audit logging issues
         frappe.logger("audit_trail").warning(f"Failed to log tool execution: {str(e)}")
+
+
+def _serialize_for_audit(output_data: Any) -> tuple:
+    """Serialize tool output for the audit row. Returns (json_str_or_none, truncated_bool)."""
+    if output_data is None:
+        return None, False
+    try:
+        serialized = json.dumps(output_data, default=str)
+    except (TypeError, ValueError):
+        serialized = str(output_data)
+    if len(serialized) > _OUTPUT_DATA_MAX_BYTES:
+        return serialized[:_OUTPUT_DATA_MAX_BYTES], True
+    return serialized, False
 
 
 def log_tool_discovery(app_name: str, tools_found: int, errors: int, discovery_time: float):
@@ -181,24 +248,26 @@ def log_tool_discovery(app_name: str, tools_found: int, errors: int, discovery_t
         discovery_time: Time taken for discovery
     """
     try:
+        payload = {
+            "app_name": app_name,
+            "tools_found": tools_found,
+            "errors": errors,
+            "discovery_time": discovery_time,
+        }
+        output_str, truncated = _serialize_for_audit(payload)
         audit_doc = frappe.get_doc(
             {
                 "doctype": "Assistant Audit Log",
                 "action": "discover_tools",
                 "user": frappe.session.user or "System",
-                "status": "Success" if errors == 0 else "Partial",
+                "status": AUDIT_STATUS_SUCCESS if errors == 0 else AUDIT_STATUS_ERROR,
                 "timestamp": now(),
+                "execution_time": discovery_time,
                 "target_doctype": "Tool Discovery",
                 "target_name": app_name,
-                "details": json.dumps(
-                    {
-                        "app_name": app_name,
-                        "tools_found": tools_found,
-                        "errors": errors,
-                        "discovery_time": discovery_time,
-                    },
-                    default=str,
-                ),
+                "source_app": app_name,
+                "output_data": output_str,
+                "output_truncated": 1 if truncated else 0,
             }
         )
 
@@ -219,19 +288,25 @@ def log_security_event(event_type: str, user: str, details: Dict[str, Any], seve
         severity: Event severity (Low, Medium, High, Critical)
     """
     try:
+        payload = {"event_type": event_type, "severity": severity, **details}
+        output_str, truncated = _serialize_for_audit(payload)
         audit_doc = frappe.get_doc(
             {
                 "doctype": "Assistant Audit Log",
                 "action": f"security_{event_type}",
                 "user": user,
-                "status": "Alert",
+                "status": AUDIT_STATUS_PERMISSION_DENIED
+                if event_type == "permission_denied"
+                else AUDIT_STATUS_ERROR,
+                "error_type": f"Security:{severity}",
                 "timestamp": now(),
                 "target_doctype": "Security Event",
                 "target_name": event_type,
+                "client_id": getattr(frappe.local, "assistant_client_id", None),
+                "session_id": getattr(frappe.local, "assistant_session_id", None),
                 "ip_address": getattr(frappe.local, "request_ip", None),
-                "details": json.dumps(
-                    {"event_type": event_type, "severity": severity, **details}, default=str
-                ),
+                "output_data": output_str,
+                "output_truncated": 1 if truncated else 0,
             }
         )
 

--- a/frappe_assistant_core/utils/dashboard.py
+++ b/frappe_assistant_core/utils/dashboard.py
@@ -43,6 +43,7 @@ def get_frappe_port():
 
             if os.path.exists(sites_path) and os.path.isdir(sites_path):
                 if os.path.exists(config_file):
+                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
                     with open(config_file) as f:
                         common_config = json.load(f)
                         if "webserver_port" in common_config:

--- a/frappe_assistant_core/utils/enhanced_error_handling.py
+++ b/frappe_assistant_core/utils/enhanced_error_handling.py
@@ -476,7 +476,10 @@ class EnhancedErrorHandler:
                 }
             )
             audit_doc.insert(ignore_permissions=True)
-            frappe.db.commit()
+            # Error path runs while the surrounding request is unwinding; commit
+            # explicitly so the audit row survives even if the outer transaction
+            # is rolled back. nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+            frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
 
         except Exception as e:
             api_logger.error(f"Failed to log to audit trail: {str(e)}")

--- a/frappe_assistant_core/utils/enhanced_error_handling.py
+++ b/frappe_assistant_core/utils/enhanced_error_handling.py
@@ -441,19 +441,38 @@ class EnhancedErrorHandler:
     def _log_to_audit_trail(self, error_context: ErrorContext):
         """Log error to audit trail"""
         try:
+            from frappe.utils import now
+
+            # Severity + frappe context + resolution suggestions don't have
+            # dedicated columns; fold them into output_data so auditors still
+            # see them when opening the row.
+            extra_payload = {
+                "severity": error_context.severity.value,
+                "operation_id": error_context.operation_id,
+                "frappe_context": error_context.frappe_context,
+                "resolution_suggestions": error_context.resolution_suggestions,
+            }
+            try:
+                output_data_str = frappe.as_json(extra_payload)
+            except Exception:
+                output_data_str = str(extra_payload)
+
             audit_doc = frappe.get_doc(
                 {
                     "doctype": "Assistant Audit Log",
-                    "user": error_context.user,
+                    "action": error_context.tool_name or "error",
                     "tool_name": error_context.tool_name,
-                    "operation_id": error_context.operation_id,
+                    "user": error_context.user,
                     "status": "Error",
-                    "error_message": error_context.message,
                     "error_type": error_context.error_type,
-                    "severity": error_context.severity.value,
-                    "context_data": frappe.as_json(error_context.frappe_context),
-                    "stack_trace": error_context.stack_trace,
-                    "resolution_suggestions": frappe.as_json(error_context.resolution_suggestions),
+                    "error_message": error_context.message,
+                    "traceback": error_context.stack_trace,
+                    "output_data": output_data_str,
+                    "target_name": error_context.operation_id,
+                    "client_id": getattr(frappe.local, "assistant_client_id", None),
+                    "session_id": getattr(frappe.local, "assistant_session_id", None),
+                    "ip_address": getattr(frappe.local, "request_ip", None),
+                    "timestamp": now(),
                 }
             )
             audit_doc.insert(ignore_permissions=True)

--- a/frappe_assistant_core/utils/migration_hooks.py
+++ b/frappe_assistant_core/utils/migration_hooks.py
@@ -272,6 +272,7 @@ def _install_system_prompt_categories():
             frappe.logger("migration_hooks").warning(f"Prompt category data not found at {data_path}")
             return
 
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
         with open(data_path) as f:
             categories = json.load(f)
 
@@ -361,6 +362,7 @@ def _install_system_prompt_templates():
             frappe.logger("migration_hooks").warning(f"Prompt template data not found at {data_path}")
             return
 
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
         with open(data_path) as f:
             templates = json.load(f)
 

--- a/frappe_assistant_core/utils/permissions.py
+++ b/frappe_assistant_core/utils/permissions.py
@@ -51,17 +51,20 @@ def get_roles(user: str) -> list:
 
 
 def get_audit_permission_query_conditions(user=None):
-    """Permission query conditions for assistant Audit Log"""
+    """Permission query conditions for Assistant Audit Log"""
     if not user:
         user = frappe.session.user
 
-    # System Manager and assistant Admin can see all audit logs
-    if "System Manager" in frappe.get_roles(user) or "assistant Admin" in frappe.get_roles(user):
+    roles = frappe.get_roles(user)
+
+    # System Manager, Assistant Admin, and Auditor can see all audit logs
+    if any(r in roles for r in ("System Manager", "Assistant Admin", "Auditor")):
         return ""
 
-    # assistant Users can only see their own audit logs
-    if "assistant User" in frappe.get_roles(user):
-        return f"`tabassistant Audit Log`.user = '{user}'"
+    # Assistant Users can only see their own audit logs
+    if "Assistant User" in roles:
+        # Escape via frappe.db.escape to avoid string-interpolation injection
+        return f"`tabAssistant Audit Log`.user = {frappe.db.escape(user)}"
 
     # No access for others
     return "1=0"

--- a/frappe_assistant_core/utils/user_context.py
+++ b/frappe_assistant_core/utils/user_context.py
@@ -68,6 +68,7 @@ def secure_user_context(username: Optional[str] = None, require_system_manager: 
 
         # Switch user context if different from current
         if target_user != original_user:
+            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — context manager restores the previous user in the finally block below
             frappe.set_user(target_user)
             context_changed = True
 

--- a/scripts/run_frappe_semgrep.sh
+++ b/scripts/run_frappe_semgrep.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run semgrep with the same rule sources CI uses (.github/workflows/linter.yml):
+#   - frappe/semgrep-rules (cloned into a cache dir, updated weekly)
+#   - r/python.lang.correctness  (semgrep registry)
+#
+# Invoked from .pre-commit-config.yaml. Receives changed files as positional
+# args from pre-commit; passes them through to semgrep.
+set -euo pipefail
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/frappe-semgrep-rules"
+RULES_REPO="https://github.com/frappe/semgrep-rules.git"
+STALE_AFTER_DAYS=7
+
+# Clone on first run, refresh if older than STALE_AFTER_DAYS.
+if [[ ! -d "$CACHE_DIR/.git" ]]; then
+  echo "Cloning Frappe semgrep rules into $CACHE_DIR..." >&2
+  git clone --depth 1 "$RULES_REPO" "$CACHE_DIR" >&2
+elif [[ -n "$(find "$CACHE_DIR" -maxdepth 0 -mtime +$STALE_AFTER_DAYS 2>/dev/null)" ]]; then
+  echo "Refreshing Frappe semgrep rules in $CACHE_DIR..." >&2
+  git -C "$CACHE_DIR" pull --ff-only --quiet >&2 || true
+  touch "$CACHE_DIR"
+fi
+
+# If pre-commit handed us no files (e.g. manual `pre-commit run`), fall back
+# to scanning the whole repo so the dev still gets coverage.
+if [[ "$#" -eq 0 ]]; then
+  exec semgrep scan --error --quiet \
+    --config "$CACHE_DIR/rules" \
+    --config "r/python.lang.correctness"
+fi
+
+exec semgrep scan --error --quiet \
+  --config "$CACHE_DIR/rules" \
+  --config "r/python.lang.correctness" \
+  "$@"


### PR DESCRIPTION
## Summary

- **Tool-reported failures (`{"success": False, "error": "..."}`) are no longer logged as Success.** `_safe_execute` now detects this pattern and writes `status="Error"`, `error_type="ToolReportedError"`. Same code path also adds explicit `Permission Denied` and `Timeout` statuses.
- **Audit row now captures what's actually needed for auditing:** `error_type`, `traceback`, `source_app`, `session_id`, `client_id`, `output_truncated` (50KB cap on `output_data`).
- **MCP session/client correlation plumbed end-to-end:** `MCPServer.handle()` reads `Mcp-Session-Id` / `X-Assistant-Client-Id` headers (and the `initialize` `clientInfo`) into `frappe.local`; the stdio bridge sends a per-process session id on every request.
- **Several pre-existing silent bugs fixed along the way:** `assistant_audit_log.py` queried lowercase `"assistant Audit Log"` (returned 0s); `permissions.py` matched lowercase role names so `Assistant User` had no row-level access to their own logs; `log_tool_discovery`/`log_security_event`/`enhanced_error_handling._log_to_audit_trail` wrote nonexistent `details`/`severity`/etc. fields and invalid `Partial`/`Alert`/`Failed` status values.

## Test plan

- [x] `bench --site frappe.assistant migrate` — schema migration applies cleanly; six new columns confirmed in `tabAssistant Audit Log`
- [x] `bench --site frappe.assistant run-tests --app frappe_assistant_core` — 114 tests pass (53 skipped, 0 failures), including 10 new tests in `test_audit_log.py`
- [x] Live smoke through `log_tool_execution` — `Success` / `Error+ToolReportedError` / `Permission Denied` rows produced with correct status, `error_type`, redacted `input_data` (`password` → `***REDACTED***`), populated `source_app`
- [x] Pre-commit hooks pass on every commit (ruff import-sort, lint, format)
- [ ] **Reviewer to verify:** call a real tool that returns `{"success": False}` (e.g. `extract_file_content` with a missing path) over the MCP HTTP endpoint and confirm the audit row shows `status=Error`, non-null `session_id`, and `client_id` populated
- [ ] **Reviewer to verify:** call two tools in one Claude Desktop conversation through the stdio bridge and confirm both rows share `session_id`

## Out of scope

- No backfill patch for legacy rows with `status="Failed"` (deliberate — rows pre-deploy stay as-is).
- Hard timeout enforcement (the `Timeout` status is reserved; nothing currently raises `TimeoutError` from a tool).
- Retention/archival policy for the audit table.