### PR TITLE
fix: ignore two historical squash-merge commits in commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,30 @@
+/**
+ * commitlint configuration.
+ *
+ * Extends @commitlint/config-conventional (angular preset) — the same ruleset
+ * referenced by .github/workflows/commitlint.yml and required by
+ * semantic-release for version-bump detection.
+ *
+ * The `ignores` list holds specific historical commits that predate strict
+ * rule enforcement and cannot be rewritten (they're referenced by merged PRs
+ * and are already on main/develop). Each predicate matches the squashed
+ * commit's subject by its PR number suffix, which is unique and stable.
+ * Every entry must cite the PR it belongs to.
+ *
+ * Do not add new entries lightly — future PRs get linted at submission time,
+ * so only squash-merge accidents from the CI-gap era belong here.
+ */
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+    extends: ['@commitlint/config-conventional'],
+    ignores: [
+        // PR #145 — feat: Skills subsystem — FAC Skill DocType, admin tabs,
+        // external app registration. Squash-merged with "Skills" in
+        // sentence-case after the colon, violating subject-case.
+        (message) => message.includes('(#145)') && message.includes('Skills subsystem'),
+
+        // PR #143 — Fix audit log false-success and enrich captured fields.
+        // Squash-merged without a conventional-commit type prefix ("Fix"
+        // instead of "fix:"), violating both type-empty and subject-case.
+        (message) => message.includes('(#143)') && message.includes('Fix audit log false-success'),
+    ],
 };


### PR DESCRIPTION
## Summary

Adds a surgical `ignores` list to [\`commitlint.config.js\`](../blob/bug/commitlint-ignore-historical/commitlint.config.js) covering two squash-merge commits from before pre-commit commitlint enforcement was strong:

- **PR #145** — \`feat: Skills subsystem — FAC Skill DocType, admin tabs, external app registration (#145)\` → subject has \"Skills\" capitalised after the colon (violates \`subject-case\`)
- **PR #143** — \`Fix audit log false-success and enrich captured fields (#143)\` → missing \`fix:\` prefix (violates \`type-empty\` and \`subject-case\`)

Both commits are already on main's history via earlier releases and are referenced by closed PRs, so rewriting them is not an option. Without this ignore, any release PR (like the current [#147](https://github.com/buildswithpaul/Frappe_Assistant_Core/pull/147)) that walks \`main..develop\` trips commitlint on these two.

Each ignore predicate matches both the unique \`(#NNN)\` PR-number suffix AND a subject-text anchor, so it cannot be spoofed by unrelated future commits. The file's docblock documents why new entries should not be added lightly — every future PR still gets the full ruleset.

## Why not fix the commits?

1. They're on \`main\` via the v2.3.3 / v2.3.4 releases and their SHAs are linked from the merged PRs and release notes. Rewriting invalidates all of that.
2. \`develop\` is a protected branch; force-pushing a rewritten history is blocked.
3. Future PRs get commitlinted at submission time, so this is truly a two-commit cleanup debt, not a recurring quality regression.

## Test plan

Tested locally against five subjects:

| Input | Expected | Got |
|---|---|---|
| \`Fix audit log false-success and enrich captured fields\` (no marker) | FAIL | ✅ FAIL (2 errors) |
| \`Fix audit log false-success and enrich captured fields (#143)\` | PASS (ignored) | ✅ PASS |
| \`feat: Skills subsystem — FAC Skill DocType (#145)\` | PASS (ignored) | ✅ PASS |
| \`Bad Commit Without Type\` | FAIL | ✅ FAIL (2 errors) |
| \`fix: drop unused libs from sandbox\` | PASS | ✅ PASS |

## Unblocks

[PR #147 — Release v2.4.0](https://github.com/buildswithpaul/Frappe_Assistant_Core/pull/147). After this merges to develop, #147 needs its develop branch refreshed so the new config is in scope; commitlint will then pass.