### PR TITLE
fix: accept JSON-string roles in update_tool_role_access

### DIFF
--- a/frappe_assistant_core/api/admin/tools.py
+++ b/frappe_assistant_core/api/admin/tools.py
@@ -388,7 +388,7 @@ def update_tool_category(tool_name: str, category: str, override: bool = True):
 
 
 @frappe.whitelist(methods=["POST"])
-def update_tool_role_access(tool_name: str, role_access_mode: str, roles: list = None):
+def update_tool_role_access(tool_name: str, role_access_mode: str, roles: list | str = None):
     """
     Update role access settings for a tool.
 


### PR DESCRIPTION
Closes #160

## Summary

- Fixes a 417 EXPECTATION FAILED error when saving role access from the FAC admin tools panel (gear icon → "Restrict to Listed Roles" → Save).
- Root cause: `frappe.call` serializes nested arrays as JSON strings over form encoding. The strict `roles: list` type hint on `update_tool_role_access` caused pydantic to reject the payload at the parameter-validation boundary, before the function body's existing `json.loads` shim could parse it.
- Fix: widen the annotation to `list | str` so pydantic accepts either form and the existing string-handling path runs.

## Test plan

- [ ] Open FAC admin page, click the settings gear on any tool, switch to "Restrict to Listed Roles", add a role, click Save — should succeed without a 417 error.
- [ ] Repeat with multiple roles to confirm the list is persisted correctly on `FAC Tool Configuration`.
- [ ] Switch back to "Allow All" and save — should still succeed (roles arg empty/None).

🤖 Generated with [Claude Code](https://claude.com/claude-code)