### PR TITLE
fix: validate required fields against populated doc in create_document

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/create_document.py
+++ b/frappe_assistant_core/plugins/core/tools/create_document.py
@@ -158,22 +158,6 @@ class DocumentCreate(BaseTool):
             meta = frappe.get_meta(doctype)
             table_fields = {f.fieldname: f.options for f in meta.fields if f.fieldtype == "Table"}
 
-            # Validate required fields
-            required_fields = [
-                f.fieldname for f in meta.fields if f.reqd and not f.default and f.fieldtype != "Table"
-            ]
-            missing_fields = [f for f in required_fields if f not in data or not data[f]]
-
-            if missing_fields:
-                return {
-                    "success": False,
-                    "error": f"Missing required fields: {', '.join(missing_fields)}",
-                    "required_fields": required_fields,
-                    "provided_fields": list(data.keys()),
-                    "suggestion": f"Use get_doctype_info tool with doctype='{doctype}' to see all required fields and their types",
-                    "doctype": doctype,
-                }
-
             # Set field values with proper child table handling
             for field, value in data.items():
                 if field in table_fields:
@@ -191,6 +175,24 @@ class DocumentCreate(BaseTool):
                 else:
                     # Handle regular fields
                     setattr(doc, field, value)
+
+            # Validate required fields against the populated doc, not the raw
+            # input. Fields auto-populated by new_doc() (company, naming_series,
+            # selling_price_list, etc.) carry no static `default` on the
+            # docfield, so checking `data` alone produces false "missing field"
+            # errors for values Frappe has already filled in.
+            required_fields = [f.fieldname for f in meta.fields if f.reqd and f.fieldtype != "Table"]
+            missing_fields = [f for f in required_fields if not doc.get(f)]
+
+            if missing_fields:
+                return {
+                    "success": False,
+                    "error": f"Missing required fields: {', '.join(missing_fields)}",
+                    "required_fields": required_fields,
+                    "provided_fields": list(data.keys()),
+                    "suggestion": f"Use get_doctype_info tool with doctype='{doctype}' to see all required fields and their types",
+                    "doctype": doctype,
+                }
 
             # Handle validation-only mode
             if validate_only:


### PR DESCRIPTION
## Summary

- The `create_document` tool's pre-insert required-field check rejected requests for fields that Frappe had already populated. Specifically, the check looked at the user-supplied `data` dict before any defaults were applied, and the docfield filter only skipped fields that had a static `default` attribute on the docfield itself.
- Fields populated dynamically by `frappe.new_doc()` — `company` from User permissions, `selling_price_list` from Selling Settings, `naming_series` from autoname rules, and similar — carry no static `default`, so the check raised false "Missing required fields: company, selling_price_list, naming_series" errors even when the doc had those values already filled in.
- Fix: assign the user values onto the doc first, then check `doc.get(fieldname)` instead of `data[fieldname]`. The `not f.default` filter is no longer needed — the populated-doc check naturally covers both static-default and dynamically-populated cases.

## Type of Change

- [x] Bug fix

## Related Issues

Closes #165

## Test plan

- [x] `create_document` for a `Quotation` providing only `quotation_to`, `party_name`, `transaction_date`, and `items` succeeds (was failing with false "Missing required fields: company, selling_price_list, naming_series" — see issue #165 reproducer).
- [x] `create_document` with a genuinely missing required field still returns the structured `Missing required fields` error response with `required_fields` / `provided_fields` / `suggestion`.
- [x] Existing test `test_error_handling_scenarios` (passes empty args to `create_document`) still produces a dict-shaped error response.
- [x] Existing test `test_create_document_basic` still creates documents successfully.