### PR TITLE
fix: pass user_role to filter_sensitive_fields in chatgpt_fetch

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/chatgpt_fetch.py
+++ b/frappe_assistant_core/plugins/core/tools/chatgpt_fetch.py
@@ -77,6 +77,11 @@ class ChatGPTFetch(BaseTool):
             - url: URL for citation
             - metadata: Additional document metadata
         """
+        from frappe_assistant_core.core.security_config import (
+            filter_sensitive_fields,
+            validate_document_access,
+        )
+
         try:
             doc_id = arguments.get("id", "").strip()
 
@@ -89,17 +94,20 @@ class ChatGPTFetch(BaseTool):
 
             doctype, name = doc_id.split("/", 1)
 
-            # Get document using existing functionality
+            # Layered permission check: role-based doctype gating + Frappe perms.
+            # Mirrors the get_document tool so the ChatGPT fetch path doesn't
+            # bypass FAC's standard auth pipeline.
+            validation_result = validate_document_access(
+                user=frappe.session.user, doctype=doctype, name=name, perm_type="read"
+            )
+            if not validation_result["success"]:
+                raise frappe.PermissionError(
+                    validation_result.get("error", f"Access denied for {doctype} {name}")
+                )
+
+            user_role = validation_result["role"]
             doc = frappe.get_doc(doctype, name)
-
-            # Check permissions
-            if not doc.has_permission("read"):
-                raise frappe.PermissionError(f"No read permission for {doctype} {name}")
-
-            # Filter sensitive fields
-            from frappe_assistant_core.core.security_config import filter_sensitive_fields
-
-            doc_dict = filter_sensitive_fields(doc.as_dict(), doctype)
+            doc_dict = filter_sensitive_fields(doc.as_dict(), doctype, user_role)
 
             # Create title from name field or document name
             title = doc_dict.get("title") or doc_dict.get("name") or name
@@ -124,16 +132,17 @@ class ChatGPTFetch(BaseTool):
         except frappe.DoesNotExistError:
             error_msg = f"Document not found: {doc_id}"
             frappe.log_error(title=_("ChatGPT Fetch Error"), message=error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(error_msg) from None
 
         except frappe.PermissionError as e:
             error_msg = f"Permission denied: {str(e)}"
             frappe.log_error(title=_("ChatGPT Fetch Permission Error"), message=error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(error_msg) from e
 
-        except Exception as e:
-            frappe.log_error(title=_("ChatGPT Fetch Error"), message=f"Error fetching document: {str(e)}")
-            raise ValueError(f"Error fetching document: {str(e)}")
+        except ValueError:
+            # Input validation errors raised above ("Document ID is required",
+            # "Invalid document ID format", ...) — surface as-is.
+            raise
 
     def _format_document_as_text(self, doc_dict: Dict, doctype: str, name: str) -> str:
         """


### PR DESCRIPTION
## Summary

- The `chatgpt_fetch` tool crashed on **every call** with `TypeError: filter_sensitive_fields() missing 1 required positional argument: 'user_role'`. `filter_sensitive_fields` was extended to require a third positional `user_role` argument; the MCP-path callers (`get_document`, `list_documents`) were updated, but `chatgpt_fetch` was missed.
- The reason `user_role` was missing wasn't just a forgotten argument — `chatgpt_fetch` was bypassing FAC's standard auth pipeline entirely, using a bare `doc.has_permission("read")` instead of `validate_document_access`. That weaker check skipped role-based doctype gating and the restricted-doctype list, and never resolved a role to pass through.
- Fix swaps the ad-hoc check for the same `validate_document_access` flow `get_document` uses, takes `user_role` from its result, and passes it through to `filter_sensitive_fields`.
- Also drops the catch-all `except Exception` that re-wrapped the underlying `TypeError` as a misleading `ValueError("Error fetching document: ...")`, which masked the real cause and forced the reporter to dig into the traceback. Unexpected exceptions now propagate to `BaseTool._safe_execute` for proper logging; explicit input-validation `ValueError`s and the existing `DoesNotExistError` / `PermissionError` paths still surface cleanly.
- Audited `chatgpt_search` — it only returns `{id, title, url}` and never calls `filter_sensitive_fields`, so no drift there. Bug is isolated to `chatgpt_fetch`.

## Type of Change

- [x] Bug fix

## Related Issues

Closes #163

## Test plan

- [x] `chatgpt_fetch` with a valid `id` (e.g. `Customer/CUST-00001`) returns the document for a System Manager user (was 100% failure before).
- [x] `chatgpt_fetch` for an Assistant User on a doctype with restricted fields actually applies `filter_sensitive_fields` and replaces sensitive values with `***RESTRICTED***` (this path was silently broken before — the crash meant filtering never executed at all, so anyone running with stricter roles deserves a verification pass).
- [x] `chatgpt_fetch` on a doctype the role can't access returns the standard layered permission error (not just the document-level one).
- [x] Bad input (`id=""`, `id="no-slash"`) still returns clean `ValueError` messages without the misleading "Error fetching document:" prefix.
- [x] `chatgpt_search` continues to work unchanged.