### PR TITLE
fix(update_document): support child-table updates; reject direct child-doctype calls

### DIFF
--- a/docs/skills/update_document.md
+++ b/docs/skills/update_document.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-The `update_document` tool modifies field values on an existing Frappe document. Only include fields that need to change.
+The `update_document` tool modifies field values on an existing Frappe document. Only include fields that need to change. Supports both top-level scalar fields and child-table rows.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `doctype` | string | **Yes** | Exact DocType name |
+| `doctype` | string | **Yes** | Exact **parent** DocType name (e.g., `Sales Order`, not `Sales Order Item`) |
 | `name` | string | **Yes** | Document name/ID to update |
-| `data` | object | **Yes** | Only the fields to change |
+| `data` | object | **Yes** | Only the fields to change. For child tables, pass a list of row dicts under the table fieldname |
 
 ## Response Format
 
@@ -38,17 +38,89 @@ The `update_document` tool modifies field values on an existing Frappe document.
 
 The response confirms which fields were updated and shows the document's current state.
 
+## Updating child-table rows
+
+Always update child rows by calling `update_document` on the **parent** document and passing the child rows under the table fieldname. The tool refuses direct calls on child-table doctypes (see [Edge Cases](#edge-cases)).
+
+The tool picks **patch mode** or **replace mode** automatically based on whether any input row carries a `name` key.
+
+### Patch mode — when any input row has a `name`
+
+Used to surgically edit specific rows. Behaviour per row:
+
+- Row has `name` → **update**: matched row's named fields are overwritten, untouched fields preserved.
+- Row has `name` and `"_delete": true` → **remove**: the row is deleted from the table.
+- Row has no `name` → **append**: a new row is added to the end.
+- Existing rows whose `name` is **not mentioned** in the input → **left untouched**.
+
+```json
+{
+  "doctype": "Sales Order",
+  "name": "SO-0001",
+  "data": {
+    "items": [
+      {"name": "abc-123", "qty": 5},
+      {"name": "abc-456", "rate": 250},
+      {"item_code": "NEW-SKU", "qty": 1, "rate": 100},
+      {"name": "abc-789", "_delete": true}
+    ]
+  }
+}
+```
+
+This: changes qty on row `abc-123`, changes rate on row `abc-456`, appends a new row, deletes row `abc-789`. Any other rows on the SO are left alone.
+
+### Replace mode — when no input row has a `name`
+
+Clears the child table and re-fills it with the rows you supply. Use this for first-time population or a deliberate "wipe and refill". Be careful: rows you omit are lost.
+
+```json
+{
+  "doctype": "Sales Order",
+  "name": "SO-0001",
+  "data": {
+    "items": [
+      {"item_code": "SKU-A", "qty": 2, "rate": 100},
+      {"item_code": "SKU-B", "qty": 1, "rate": 250}
+    ]
+  }
+}
+```
+
+### Why call on the parent, not the child
+
+ERPNext (and Frappe in general) computes derived fields — row `amount`, parent `total`, `total_qty`, `grand_total`, taxes, etc. — inside the parent doc's `validate()` pipeline. Calling `update_document` directly on a child-table doctype like `Sales Order Item` saves the row in isolation and **bypasses that pipeline**, leaving the row's `amount` and the parent's totals stale. The tool detects this and refuses.
+
 ## Best Practices
 
-1. **Fetch first with `get_document`** — understand current values before updating.
+1. **Fetch first with `get_document`** — understand current values (and child-row `name`s) before updating.
 2. **Only include changed fields** — don't send the entire document.
-3. **Link fields use the `name`** — not the display title. Use `search_link` to find valid values.
-4. **Cannot update submitted documents** — `docstatus=1` documents must be amended or cancelled first.
-5. **Child table updates replace all rows** — passing a child table array replaces ALL existing rows. Omitting leaves unchanged.
+3. **Use the parent doctype for child-row edits** — never target a child-table doctype directly.
+4. **Prefer patch mode for child tables** — it's surgical and won't drop rows you didn't mean to.
+5. **Use replace mode only when you intend a wipe-and-refill** — it discards any row you omit.
+6. **Link fields use the `name`** — not the display title. Use `search_link` to find valid values.
+7. **Cannot update submitted documents** — `docstatus=1` documents must be amended or cancelled first.
 
 ## Edge Cases
 
+- **Direct child-doctype updates are rejected.** Calling `update_document` with `doctype: "Sales Order Item"` (or any other child-table doctype) returns `error_type: "child_doctype_direct_update"` along with the parent doctype, parent name, and parent table fieldname so you can retry on the parent.
+
+  ```json
+  {
+    "success": false,
+    "error_type": "child_doctype_direct_update",
+    "child_doctype": "Sales Order Item",
+    "parent_doctype": "Sales Order",
+    "parent_name": "SO-0001",
+    "parent_table_fieldname": "items",
+    "suggestion": "Call update_document with doctype='Sales Order', name='SO-0001', and data={'items': [{'name': '...', ...fields to change...}]}. Patch mode will update only the named row; other rows are untouched."
+  }
+  ```
+
+- **Patch references a row `name` that doesn't exist** → `error_type: "child_row_not_found"`. No silent skipping.
+- **`_delete: true` without a `name`** → rejected. Deletion is only meaningful for rows already on the doc.
+- **Restricted fields in a child row** — sensitive fields registered for the *child* doctype (e.g., `secret_key`) are blocked the same way as on the parent. Error names the offending field and child doctype.
 - **Submitted documents** (`docstatus=1`) — cannot update. Use `run_workflow` to amend/cancel.
-- **Read-only fields** — computed fields (e.g., `grand_total`) cannot be set.
+- **Read-only fields** — computed fields (e.g., `grand_total`) cannot be set; they recompute on save.
 - **Validation runs on save** — invalid field combinations will fail.
-- **workflow_state** — don't update directly, use `run_workflow` instead.
+- **`workflow_state`** — don't update directly, use `run_workflow` instead.

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -19,12 +19,138 @@ Document Update Tool for Core Plugin.
 Updates existing Frappe documents.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Set
 
 import frappe
 from frappe import _
 
 from frappe_assistant_core.core.base_tool import BaseTool
+
+
+def _restricted_fields_for_doctype(doctype: str, user_role: str) -> Set[str]:
+    """Resolve the union of SENSITIVE_FIELDS + (role-conditional) ADMIN_ONLY_FIELDS for a doctype."""
+    from frappe_assistant_core.core.security_config import ADMIN_ONLY_FIELDS, SENSITIVE_FIELDS
+
+    restricted: Set[str] = set()
+    restricted.update(SENSITIVE_FIELDS.get("all_doctypes", []))
+    restricted.update(SENSITIVE_FIELDS.get(doctype, []))
+
+    if user_role == "Assistant User":
+        restricted.update(ADMIN_ONLY_FIELDS.get("all_doctypes", []))
+        doctype_admin_fields = ADMIN_ONLY_FIELDS.get(doctype, [])
+        if doctype_admin_fields != "*":
+            restricted.update(doctype_admin_fields)
+
+    return restricted
+
+
+def _apply_child_table_update(
+    doc: Any,
+    field: str,
+    child_doctype: str,
+    rows: Any,
+    restricted_child_fields: Set[str],
+) -> Optional[Dict[str, Any]]:
+    """Apply patch- or replace-mode updates to a child table on `doc`.
+
+    Mode is decided per call: if any input row has a `name`, patch mode (match by name,
+    update matched, append unmatched, delete on `_delete: True`). Otherwise replace mode
+    (clear table and re-append).
+
+    Returns None on success, or a structured error dict on failure.
+    """
+    if not isinstance(rows, list):
+        return {
+            "success": False,
+            "error": f"Child table '{field}' requires a list of dictionaries, got: {type(rows).__name__}",
+            "error_type": "child_table_handling_error",
+            "field": field,
+        }
+
+    for row in rows:
+        if not isinstance(row, dict):
+            return {
+                "success": False,
+                "error": f"Child table '{field}' rows must be dictionaries, got: {type(row).__name__}",
+                "error_type": "child_table_handling_error",
+                "field": field,
+            }
+
+    has_named_row = any("name" in row and row["name"] for row in rows)
+
+    # Reject restricted fields up-front, regardless of mode.
+    for row in rows:
+        violating = [k for k in row.keys() if k in restricted_child_fields]
+        if violating:
+            row_id = row.get("name", "<new row>")
+            return {
+                "success": False,
+                "error": (
+                    f"Cannot update restricted child-table fields: "
+                    f"{', '.join(violating)} in {child_doctype} (row {row_id}). "
+                    f"These fields require higher privileges."
+                ),
+            }
+
+    if not has_named_row:
+        # Replace mode: matches create_document semantics for first-time population.
+        if any("_delete" in row for row in rows):
+            return {
+                "success": False,
+                "error": (
+                    f"'_delete' marker on child table '{field}' requires a 'name' to identify "
+                    f"the row to remove."
+                ),
+                "error_type": "child_row_not_found",
+                "field": field,
+            }
+        doc.set(field, [])
+        for row in rows:
+            doc.append(field, row)
+        return None
+
+    # Patch mode: match input rows to existing rows by `name`.
+    existing_rows = doc.get(field) or []
+    existing_by_name = {r.name: r for r in existing_rows if getattr(r, "name", None)}
+
+    for row in rows:
+        row_name = row.get("name")
+        delete_marker = bool(row.get("_delete"))
+
+        if not row_name:
+            if delete_marker:
+                return {
+                    "success": False,
+                    "error": (
+                        f"'_delete' marker on child table '{field}' requires a 'name' to identify "
+                        f"the row to remove."
+                    ),
+                    "error_type": "child_row_not_found",
+                    "field": field,
+                }
+            # New row in patch mode → append.
+            doc.append(field, row)
+            continue
+
+        target = existing_by_name.get(row_name)
+        if target is None:
+            return {
+                "success": False,
+                "error": f"Row '{row_name}' not found in {child_doctype} table '{field}'.",
+                "error_type": "child_row_not_found",
+                "field": field,
+            }
+
+        if delete_marker:
+            doc.remove(target)
+            continue
+
+        for k, v in row.items():
+            if k in ("name", "_delete"):
+                continue
+            target.set(k, v)
+
+    return None
 
 
 class DocumentUpdate(BaseTool):
@@ -33,6 +159,7 @@ class DocumentUpdate(BaseTool):
 
     Provides capabilities for:
     - Updating document field values
+    - Updating child-table rows (replace, append, patch, delete)
     - Checking permissions
     - Handling validation errors
     """
@@ -40,7 +167,18 @@ class DocumentUpdate(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "update_document"
-        self.description = "Update/modify an existing Frappe document. Use when users want to change field values in an existing record. Always fetch the document first to understand current values."
+        self.description = (
+            "Update/modify an existing Frappe document. Use when users want to change field values "
+            "in an existing record. Always fetch the document first to understand current values. "
+            "Supports child tables: send a list of row dicts under the table fieldname. If any row "
+            "has a 'name' key, patch mode is used (rows matched by 'name' are updated, rows without "
+            "'name' are appended, rows with '_delete': true are removed). If no row has a 'name', "
+            "the entire child table is replaced. "
+            "IMPORTANT: do NOT call this tool with a child-table doctype (e.g. 'Sales Order Item', "
+            "'Purchase Order Item') directly — that bypasses the parent's recalculation and leaves "
+            "totals stale. Always call it on the parent doctype (e.g. 'Sales Order') and pass the "
+            "child row updates under the table fieldname (e.g. 'items')."
+        )
         self.requires_permission = None  # Permission checked dynamically per DocType
 
         self.inputSchema = {
@@ -56,7 +194,16 @@ class DocumentUpdate(BaseTool):
                 },
                 "data": {
                     "type": "object",
-                    "description": "Field updates as key-value pairs. Only include fields that need to be changed. Example: {'customer_name': 'Updated Corp Name', 'phone': '+1234567890'}",
+                    "description": (
+                        "Field updates as key-value pairs. Only include fields that need to be changed. "
+                        "For top-level scalar fields: {'customer_name': 'Updated Corp Name'}. "
+                        "For child tables, pass a list of row dicts under the table fieldname. "
+                        "Patch mode (any row has 'name'): matched rows are updated, unmatched rows are "
+                        "appended, rows with '_delete': true are removed; existing rows not mentioned "
+                        "are left untouched. Replace mode (no row has 'name'): the table is cleared and "
+                        "refilled. Example patch: {'items': [{'name': 'abc-123', 'qty': 5}, "
+                        "{'item_code': 'NEW', 'qty': 1}, {'name': 'old-1', '_delete': true}]}."
+                    ),
                 },
             },
             "required": ["doctype", "name", "data"],
@@ -68,9 +215,52 @@ class DocumentUpdate(BaseTool):
         name = arguments.get("name")
         data = arguments.get("data", {})
 
+        # Reject direct updates to child-table doctypes. Saving a child row in isolation
+        # bypasses the parent's validate() pipeline, so derived fields (e.g. ERPNext's
+        # row `amount` and parent `total`/`total_qty`/`grand_total`) never recompute.
+        # The caller must update the parent doc and pass the child rows through `data`.
+        try:
+            child_meta = frappe.get_meta(doctype)
+        except Exception:
+            child_meta = None
+
+        if child_meta is not None and getattr(child_meta, "istable", 0):
+            parent_info: Dict[str, Any] = {
+                "success": False,
+                "error": (
+                    f"'{doctype}' is a child-table doctype and cannot be updated directly. "
+                    f"Updating a child row in isolation skips the parent doc's validate() "
+                    f"pipeline, leaving derived fields (row totals, parent grand_total, "
+                    f"total_qty, etc.) stale. Update the parent document instead and pass "
+                    f"the child rows under the table fieldname in `data`."
+                ),
+                "error_type": "child_doctype_direct_update",
+                "child_doctype": doctype,
+            }
+
+            # Try to resolve the parent doc + table fieldname so the model can fix its call.
+            if name:
+                try:
+                    parent_name = frappe.db.get_value(doctype, name, "parent")
+                    parent_type = frappe.db.get_value(doctype, name, "parenttype")
+                    parent_field = frappe.db.get_value(doctype, name, "parentfield")
+                    if parent_name and parent_type and parent_field:
+                        parent_info["parent_doctype"] = parent_type
+                        parent_info["parent_name"] = parent_name
+                        parent_info["parent_table_fieldname"] = parent_field
+                        parent_info["suggestion"] = (
+                            f"Call update_document with doctype='{parent_type}', "
+                            f"name='{parent_name}', and data={{'{parent_field}': "
+                            f"[{{'name': '{name}', ...fields to change...}}]}}. "
+                            f"Patch mode will update only the named row; other rows are untouched."
+                        )
+                except Exception:
+                    pass
+
+            return parent_info
+
         # Import security validation
         from frappe_assistant_core.core.security_config import (
-            filter_sensitive_fields,
             validate_document_access,
         )
 
@@ -119,40 +309,37 @@ class DocumentUpdate(BaseTool):
                 }
                 return result
 
-            # Provide helpful information about document state
-            doc_state_info = {
-                "docstatus": current_docstatus,
-                "state_description": "Draft" if current_docstatus == 0 else "Unknown",
-                "workflow_state": current_workflow_state,
-                "is_editable": current_docstatus == 0,
-            }
+            # Resolve restricted fields for the parent doctype.
+            parent_restricted = _restricted_fields_for_doctype(doctype, user_role)
 
-            # Filter out sensitive fields that user shouldn't be able to update
-            from frappe_assistant_core.core.security_config import ADMIN_ONLY_FIELDS, SENSITIVE_FIELDS
+            # Get DocType metadata for proper child-table handling.
+            meta = frappe.get_meta(doctype)
+            table_fields = {f.fieldname: f.options for f in meta.fields if f.fieldtype == "Table"}
 
-            # Get restricted fields for this role and doctype
-            restricted_fields = set()
-            restricted_fields.update(SENSITIVE_FIELDS.get("all_doctypes", []))
-            restricted_fields.update(SENSITIVE_FIELDS.get(doctype, []))
-
-            if user_role == "Assistant User":
-                restricted_fields.update(ADMIN_ONLY_FIELDS.get("all_doctypes", []))
-                doctype_admin_fields = ADMIN_ONLY_FIELDS.get(doctype, [])
-                if doctype_admin_fields != "*":
-                    restricted_fields.update(doctype_admin_fields)
-
-            # Check for attempts to update restricted fields
-            restricted_updates = [field for field in data.keys() if field in restricted_fields]
-            if restricted_updates:
-                result = {
+            # Top-level restricted-field check (excludes child-table fields, which are checked
+            # separately against the child doctype's restricted set).
+            restricted_top_level = [
+                field for field in data.keys() if field in parent_restricted and field not in table_fields
+            ]
+            if restricted_top_level:
+                return {
                     "success": False,
-                    "error": f"Cannot update restricted fields: {', '.join(restricted_updates)}. These fields require higher privileges.",
+                    "error": (
+                        f"Cannot update restricted fields: {', '.join(restricted_top_level)}. "
+                        f"These fields require higher privileges."
+                    ),
                 }
-                return result
 
-            # Update field values
+            # Apply updates: child tables go through helper, scalars use setattr.
             for field, value in data.items():
-                setattr(doc, field, value)
+                if field in table_fields:
+                    child_doctype = table_fields[field]
+                    child_restricted = _restricted_fields_for_doctype(child_doctype, user_role)
+                    err = _apply_child_table_update(doc, field, child_doctype, value, child_restricted)
+                    if err is not None:
+                        return err
+                else:
+                    setattr(doc, field, value)
 
             # Save document
             doc.save()

--- a/frappe_assistant_core/tests/test_document_tools.py
+++ b/frappe_assistant_core/tests/test_document_tools.py
@@ -263,6 +263,44 @@ class TestDocumentTools(BaseAssistantTest):
             # Permission exceptions are acceptable
             pass
 
+    def test_update_document_rejects_child_doctype(self):
+        """Direct updates to a child-table doctype must be rejected with a clear suggestion.
+
+        Saving a child row in isolation bypasses the parent's validate() pipeline,
+        leaving parent totals (grand_total, total_qty, etc.) stale. The tool should
+        refuse and point the caller at the parent doc.
+
+        The tool registry raises on success=False results, so we exercise the tool
+        class directly to inspect the structured error payload.
+        """
+        from frappe_assistant_core.plugins.core.tools.update_document import DocumentUpdate
+
+        # "DocField" is a built-in child of "DocType" — guaranteed to exist.
+        if not frappe.db.exists("DocType", "DocField"):
+            self.skipTest("DocField doctype not available in this site")
+
+        existing = frappe.db.get_all("DocField", limit=1, fields=["name"])
+        row_name = existing[0].name if existing else "nonexistent-row"
+
+        result = DocumentUpdate().execute(
+            {
+                "doctype": "DocField",
+                "name": row_name,
+                "data": {"label": "Should Be Rejected"},
+            }
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result.get("success"))
+        self.assertEqual(result.get("error_type"), "child_doctype_direct_update")
+        self.assertEqual(result.get("child_doctype"), "DocField")
+        # When the row exists we should get parent-resolution hints back.
+        if existing:
+            self.assertIn("parent_doctype", result)
+            self.assertIn("parent_name", result)
+            self.assertIn("parent_table_fieldname", result)
+            self.assertIn("suggestion", result)
+
 
 class TestDocumentToolsIntegration(BaseAssistantTest):
     """Integration tests for document tools"""
@@ -328,3 +366,199 @@ class TestDocumentToolsIntegration(BaseAssistantTest):
                 except Exception:
                     # Exceptions are also acceptable for invalid input
                     pass
+
+
+class _FakeChildRow:
+    """Stand-in for a Frappe child docrow. Captures field updates and a stable name."""
+
+    def __init__(self, name=None, **fields):
+        self.name = name
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+    def set(self, key, value):
+        setattr(self, key, value)
+
+
+class _FakeDoc:
+    """Stand-in for a Frappe parent doc. Holds named child-table lists and supports
+    the subset of the doc API used by _apply_child_table_update."""
+
+    def __init__(self, tables):
+        # tables: dict[fieldname] -> list[_FakeChildRow]
+        self._tables = {k: list(v) for k, v in tables.items()}
+
+    def get(self, field):
+        return self._tables.get(field)
+
+    def set(self, field, value):
+        self._tables[field] = list(value)
+
+    def append(self, field, row_data):
+        # Mirror Frappe's behavior: append a new row built from a dict.
+        if not isinstance(row_data, dict):
+            raise TypeError(f"append expected dict, got {type(row_data).__name__}")
+        # Strip control keys before constructing the row.
+        clean = {k: v for k, v in row_data.items() if k not in ("_delete",)}
+        new_row = _FakeChildRow(**clean)
+        self._tables.setdefault(field, []).append(new_row)
+        return new_row
+
+    def remove(self, row):
+        for rows in self._tables.values():
+            if row in rows:
+                rows.remove(row)
+                return
+        raise ValueError("row not found in any table")
+
+
+class TestApplyChildTableUpdate(unittest.TestCase):
+    """Unit tests for _apply_child_table_update — DB-independent."""
+
+    def _import_helper(self):
+        from frappe_assistant_core.plugins.core.tools.update_document import (
+            _apply_child_table_update,
+        )
+
+        return _apply_child_table_update
+
+    def test_replace_mode_clears_and_appends(self):
+        helper = self._import_helper()
+        doc = _FakeDoc(
+            {
+                "items": [
+                    _FakeChildRow(name="r1", item_code="OLD-A", qty=1),
+                    _FakeChildRow(name="r2", item_code="OLD-B", qty=2),
+                ]
+            }
+        )
+        rows = [{"item_code": "NEW-A", "qty": 10}, {"item_code": "NEW-B", "qty": 20}]
+
+        err = helper(doc, "items", "Sales Order Item", rows, set())
+
+        self.assertIsNone(err)
+        items = doc.get("items")
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].item_code, "NEW-A")
+        self.assertEqual(items[0].qty, 10)
+        self.assertEqual(items[1].item_code, "NEW-B")
+        # No retained rows from before.
+        self.assertNotIn("OLD-A", [getattr(r, "item_code", None) for r in items])
+
+    def test_patch_mode_updates_matched_row_leaves_others(self):
+        helper = self._import_helper()
+        doc = _FakeDoc(
+            {
+                "items": [
+                    _FakeChildRow(name="r1", item_code="A", qty=1),
+                    _FakeChildRow(name="r2", item_code="B", qty=2),
+                ]
+            }
+        )
+
+        err = helper(doc, "items", "Sales Order Item", [{"name": "r1", "qty": 99}], set())
+
+        self.assertIsNone(err)
+        items = doc.get("items")
+        self.assertEqual(len(items), 2)
+        r1 = next(r for r in items if r.name == "r1")
+        r2 = next(r for r in items if r.name == "r2")
+        self.assertEqual(r1.qty, 99)
+        self.assertEqual(r1.item_code, "A")  # untouched scalar preserved
+        self.assertEqual(r2.qty, 2)  # other row untouched
+        self.assertEqual(r2.item_code, "B")
+
+    def test_patch_mode_appends_unnamed_rows(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": [_FakeChildRow(name="r1", item_code="A", qty=1)]})
+
+        err = helper(
+            doc,
+            "items",
+            "Sales Order Item",
+            [{"name": "r1", "qty": 5}, {"item_code": "NEW", "qty": 7}],
+            set(),
+        )
+
+        self.assertIsNone(err)
+        items = doc.get("items")
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].qty, 5)
+        self.assertEqual(items[1].item_code, "NEW")
+        self.assertEqual(items[1].qty, 7)
+
+    def test_patch_mode_delete_marker_removes_row(self):
+        helper = self._import_helper()
+        doc = _FakeDoc(
+            {
+                "items": [
+                    _FakeChildRow(name="r1", item_code="A", qty=1),
+                    _FakeChildRow(name="r2", item_code="B", qty=2),
+                ]
+            }
+        )
+
+        err = helper(doc, "items", "Sales Order Item", [{"name": "r1", "_delete": True}], set())
+
+        self.assertIsNone(err)
+        items = doc.get("items")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].name, "r2")
+
+    def test_delete_marker_without_name_errors(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": [_FakeChildRow(name="r1", item_code="A", qty=1)]})
+
+        err = helper(doc, "items", "Sales Order Item", [{"_delete": True, "qty": 5}], set())
+
+        self.assertIsNotNone(err)
+        self.assertFalse(err["success"])
+        self.assertEqual(err["error_type"], "child_row_not_found")
+
+    def test_patch_mode_unknown_name_errors(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": [_FakeChildRow(name="r1", item_code="A", qty=1)]})
+
+        err = helper(doc, "items", "Sales Order Item", [{"name": "does-not-exist", "qty": 5}], set())
+
+        self.assertIsNotNone(err)
+        self.assertFalse(err["success"])
+        self.assertEqual(err["error_type"], "child_row_not_found")
+
+    def test_restricted_field_in_child_row_rejected(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": [_FakeChildRow(name="r1", item_code="A", qty=1)]})
+
+        err = helper(
+            doc,
+            "items",
+            "Sales Order Item",
+            [{"name": "r1", "qty": 5, "secret_key": "leak"}],
+            {"secret_key"},
+        )
+
+        self.assertIsNotNone(err)
+        self.assertFalse(err["success"])
+        self.assertIn("secret_key", err["error"])
+        # Original row untouched on rejection.
+        self.assertEqual(doc.get("items")[0].qty, 1)
+
+    def test_value_not_a_list_errors(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": []})
+
+        err = helper(doc, "items", "Sales Order Item", {"item_code": "A"}, set())
+
+        self.assertIsNotNone(err)
+        self.assertFalse(err["success"])
+        self.assertEqual(err["error_type"], "child_table_handling_error")
+
+    def test_row_not_a_dict_errors(self):
+        helper = self._import_helper()
+        doc = _FakeDoc({"items": []})
+
+        err = helper(doc, "items", "Sales Order Item", ["not-a-dict"], set())
+
+        self.assertIsNotNone(err)
+        self.assertFalse(err["success"])
+        self.assertEqual(err["error_type"], "child_table_handling_error")


### PR DESCRIPTION
## Summary

Closes #168 (item 1 — child-table updates in `update_document`).

- **Child-table updates** are now supported through the parent doc, with **patch** or **replace** semantics chosen per-table from the input shape:
  - Any row carrying a `name` ⇒ **patch mode**: matched rows updated, unmatched rows appended, rows with `_delete: true` removed; rows not mentioned are left untouched.
  - No `name` on any row ⇒ **replace mode**: child table is cleared and re-appended (matches `create_document` semantics).
  - Restricted-field filtering now extends to child rows using the **child** doctype's `SENSITIVE_FIELDS` / `ADMIN_ONLY_FIELDS`.
- **Direct calls on a child-table doctype are rejected** (e.g. `doctype: "Sales Order Item"`). Saving a child row in isolation bypasses the parent's `validate()` pipeline, leaving derived fields (row `amount`, parent `total` / `total_qty` / `grand_total`) stale. The tool resolves the parent doc + table fieldname and returns a structured `child_doctype_direct_update` error with a ready-to-retry suggestion.
- **Skill doc** (`docs/skills/update_document.md`) updated with patch/replace examples, the rejection error shape, and best-practice guidance.

Item 2 of the issue (attachment uploads) is **not** addressed — blocked by the Claude MCP client per the issue thread.

## Test plan

- [x] Unit tests for `_apply_child_table_update`: replace mode clears+appends, patch updates matched rows leaving others untouched, patch appends unnamed rows, `_delete: true` removes rows, `_delete` without `name` errors, unknown patch `name` errors, restricted child-row field rejected, non-list value rejected, non-dict row rejected.
- [x] Test for `child_doctype_direct_update` rejection (uses `DocField` as the built-in child to keep the test self-contained).
- [x] All 24 tests in `test_document_tools.py` pass.
- [x] Live verification on `icp.test`:
  - Patch mode (qty 2→7) recomputes row `amount` and parent totals correctly.
  - Patch + append in one call recomputes correctly.
  - Direct `doctype: "Sales Order Item"` call now returns the structured rejection with `parent_doctype`, `parent_name`, `parent_table_fieldname`, and a ready-to-retry suggestion.

