### PR TITLE
fix(create_document): drop pre-flight reqd check, defer to Frappe validate() (#165 follow-up)

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/create_document.py
+++ b/frappe_assistant_core/plugins/core/tools/create_document.py
@@ -176,23 +176,13 @@ class DocumentCreate(BaseTool):
                     # Handle regular fields
                     setattr(doc, field, value)
 
-            # Validate required fields against the populated doc, not the raw
-            # input. Fields auto-populated by new_doc() (company, naming_series,
-            # selling_price_list, etc.) carry no static `default` on the
-            # docfield, so checking `data` alone produces false "missing field"
-            # errors for values Frappe has already filled in.
-            required_fields = [f.fieldname for f in meta.fields if f.reqd and f.fieldtype != "Table"]
-            missing_fields = [f for f in required_fields if not doc.get(f)]
-
-            if missing_fields:
-                return {
-                    "success": False,
-                    "error": f"Missing required fields: {', '.join(missing_fields)}",
-                    "required_fields": required_fields,
-                    "provided_fields": list(data.keys()),
-                    "suggestion": f"Use get_doctype_info tool with doctype='{doctype}' to see all required fields and their types",
-                    "doctype": doctype,
-                }
+            # Required-field checks are deferred to Frappe's own validation pipeline
+            # via doc.insert()/doc.run_method("validate"). A pre-flight check here is
+            # unreliable: many "reqd" fields (e.g. Quotation.conversion_rate,
+            # price_list_currency, plc_conversion_rate) are populated by the
+            # doctype controller's set_missing_values() during validate(), which has
+            # not yet run when we'd inspect doc.get(f). MandatoryError is caught
+            # below and translated into the same structured error shape.
 
             # Handle validation-only mode
             if validate_only:
@@ -264,6 +254,36 @@ class DocumentCreate(BaseTool):
             # Log successful creation
             return result
 
+        except frappe.MandatoryError as e:
+            # Frappe raises MandatoryError after set_missing_values() has run, so the
+            # missing fieldnames here are genuine — not the false positives we'd see
+            # from a pre-flight `reqd`-flag check on the raw input. Format:
+            #   "[<doctype>, <name>]: <fieldname1>, <fieldname2>, ..."
+            error_msg = str(e)
+            try:
+                _, _, fields_part = error_msg.partition(": ")
+                missing = [f.strip() for f in fields_part.split(",") if f.strip()]
+            except Exception:
+                missing = []
+
+            return {
+                "success": False,
+                "error": (
+                    f"Missing required fields: {', '.join(missing)}"
+                    if missing
+                    else f"Missing required fields. Raw error: {error_msg}"
+                ),
+                "error_type": "missing_required_field",
+                "doctype": doctype,
+                "missing_fields": missing,
+                "provided_fields": list(data.keys()),
+                "suggestion": (
+                    f"Use get_doctype_info tool with doctype='{doctype}' to see all required "
+                    f"fields and supply values for: {', '.join(missing)}."
+                    if missing
+                    else f"Use get_doctype_info tool with doctype='{doctype}' to see all required fields."
+                ),
+            }
         except Exception as e:
             frappe.log_error(
                 title=_("Document Creation Error"), message=f"Error creating {doctype}: {str(e)}"
@@ -290,14 +310,6 @@ class DocumentCreate(BaseTool):
                         "error_type": "validation_error",
                         "guidance": "Referenced record does not exist in the system.",
                         "suggestion": "1. Verify that referenced records (like customers, items, suppliers) exist\n2. Use search_documents tool to find correct record names\n3. Check spelling and exact names",
-                    }
-                )
-            elif "mandatory" in error_msg.lower() or "required" in error_msg.lower():
-                result.update(
-                    {
-                        "error_type": "missing_required_field",
-                        "guidance": "Required field is missing or empty.",
-                        "suggestion": f"1. Use get_doctype_info tool with doctype='{doctype}' to see all required fields\n2. Ensure all required fields are provided with valid values",
                     }
                 )
             elif "permission" in error_msg.lower():

--- a/frappe_assistant_core/tests/test_document_tools.py
+++ b/frappe_assistant_core/tests/test_document_tools.py
@@ -263,6 +263,65 @@ class TestDocumentTools(BaseAssistantTest):
             # Permission exceptions are acceptable
             pass
 
+    def test_create_document_no_false_positive_for_set_missing_values_fields(self):
+        """Issue #165 follow-up: fields populated by Frappe's set_missing_values()
+        during validate() must not be flagged as missing.
+
+        Quotation has reqd fields (conversion_rate, price_list_currency,
+        plc_conversion_rate) that new_doc() does NOT populate — they're filled
+        by the doctype controller's set_missing_values() during validate(),
+        which runs inside doc.insert(). A pre-flight check that inspects
+        doc.get(f) before insert() returns false positives for these.
+        """
+        from frappe_assistant_core.plugins.core.tools.create_document import DocumentCreate
+
+        if not frappe.db.exists("DocType", "Quotation"):
+            self.skipTest("Quotation doctype not available (ERPNext not installed)")
+
+        cust = frappe.get_all("Customer", limit=1, pluck="name")
+        item = frappe.get_all("Item", filters={"is_sales_item": 1, "disabled": 0}, limit=1, pluck="name")
+        if not (cust and item):
+            self.skipTest("No Customer/Item available for test")
+
+        result = DocumentCreate().execute(
+            {
+                "doctype": "Quotation",
+                "data": {
+                    "quotation_to": "Customer",
+                    "party_name": cust[0],
+                    "transaction_date": frappe.utils.nowdate(),
+                    "items": [{"item_code": item[0], "qty": 1, "rate": 100}],
+                },
+            }
+        )
+
+        # Whichever way it lands (success, or genuine missing field like
+        # enquiry_reference per site config), it must NOT report any of the
+        # set_missing_values()-populated fields as missing.
+        false_positives = {"conversion_rate", "price_list_currency", "plc_conversion_rate"}
+        if not result.get("success"):
+            missing = set(result.get("missing_fields") or [])
+            leaked = missing & false_positives
+            self.assertFalse(
+                leaked,
+                f"set_missing_values() fields incorrectly reported as missing: {leaked}. "
+                f"Full error: {result.get('error')}",
+            )
+            # If it failed, it must be for a different (genuine) reason.
+            if missing:
+                # Genuine missing field is fine — the structured error shape
+                # is the contract here.
+                self.assertEqual(result.get("error_type"), "missing_required_field")
+                self.assertIn("provided_fields", result)
+                self.assertIn("suggestion", result)
+        else:
+            # Cleanup if the create actually succeeded.
+            try:
+                frappe.delete_doc("Quotation", result["name"], ignore_permissions=True, force=True)
+                frappe.db.commit()
+            except Exception:
+                pass
+
     def test_update_document_rejects_child_doctype(self):
         """Direct updates to a child-table doctype must be rejected with a clear suggestion.
 


### PR DESCRIPTION
## Summary

Follow-up to #165. The earlier fix is incomplete: it still runs a required-fields check **before** `doc.insert()`, which means fields populated by the doctype controller's `set_missing_values()` (called inside `validate()`) are still flagged as missing.

Concrete reproducer — calling `create_document` for a Quotation with the documented minimal fields:

```json
{
  "doctype": "Quotation",
  "data": {
    "quotation_to": "Customer",
    "party_name": "...",
    "transaction_date": "2026-05-07",
    "items": [{"item_code": "...", "qty": 1, "rate": 100}]
  }
}
```

still returns:

```
Missing required fields: conversion_rate, price_list_currency, plc_conversion_rate
```

These three fields are populated by `Quotation.set_missing_values()` inside `validate()`. They are **never** set by `new_doc()`, so any pre-`insert()` check sees them as `None`.

## Fix

Delete the pre-flight check entirely and let Frappe's own `_validate_mandatory()` be the authority — it runs **after** `set_missing_values()`, so it never sees those false positives. `frappe.MandatoryError` is now caught explicitly and translated into the same structured error shape the pre-flight check used to produce (`error_type: "missing_required_field"`, `missing_fields`, `provided_fields`, `suggestion`).

## Test plan

- [x] New regression test `test_create_document_no_false_positive_for_set_missing_values_fields` against Quotation (skipped if ERPNext / Customer / Item not present). Asserts that `conversion_rate`, `price_list_currency`, `plc_conversion_rate` never appear in `missing_fields`.
- [x] All 15 tests in `test_document_tools.py` pass.
- [x] Live verification on `icp.test`: same payload that previously returned 4 false positives now returns only `enquiry_reference` (a genuinely-required field on this site, not a false positive). The structured shape (`error_type`, `missing_fields`, `provided_fields`, `suggestion`) is preserved.

## Note on relationship to #171

This is independent of #171 (child-table updates). Either can land first; no merge conflict expected since they touch different files (`create_document.py` here vs `update_document.py` in #171). The new test in this PR is positioned ahead of where the #171 tests would land, so file-level conflicts are unlikely either way.

