### PR TITLE
fix(create_document): don't shadow translation function `_` in MandatoryError handler

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/create_document.py
+++ b/frappe_assistant_core/plugins/core/tools/create_document.py
@@ -259,9 +259,14 @@ class DocumentCreate(BaseTool):
             # missing fieldnames here are genuine — not the false positives we'd see
             # from a pre-flight `reqd`-flag check on the raw input. Format:
             #   "[<doctype>, <name>]: <fieldname1>, <fieldname2>, ..."
+            # Don't bind `_` here — `_` is the translation function imported at
+            # module scope. Any local `_ = ...` would shadow it for the entire
+            # function body, raising UnboundLocalError at the later `_("...")`
+            # call inside the generic-Exception branch on paths that route
+            # through the function before reaching that local assignment.
             error_msg = str(e)
             try:
-                _, _, fields_part = error_msg.partition(": ")
+                fields_part = error_msg.partition(": ")[2]
                 missing = [f.strip() for f in fields_part.split(",") if f.strip()]
             except Exception:
                 missing = []

--- a/frappe_assistant_core/tests/test_document_tools.py
+++ b/frappe_assistant_core/tests/test_document_tools.py
@@ -322,6 +322,77 @@ class TestDocumentTools(BaseAssistantTest):
             except Exception:
                 pass
 
+    def test_create_document_mandatory_error_returns_structured_response(self):
+        """When Frappe raises MandatoryError, the tool returns the structured
+        missing-fields response (not a raw error string).
+
+        ToDo has a single mandatory field (`description`) that is NOT populated
+        by set_missing_values, so omitting it reliably triggers MandatoryError
+        across sites.
+        """
+        from frappe_assistant_core.plugins.core.tools.create_document import DocumentCreate
+
+        result = DocumentCreate().execute(
+            {
+                "doctype": "ToDo",
+                "data": {"date": frappe.utils.nowdate()},
+            }
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result.get("success"), f"ToDo create with no description should fail: {result}")
+        self.assertEqual(result.get("error_type"), "missing_required_field")
+        self.assertIn("description", result.get("missing_fields") or [])
+        self.assertEqual(result.get("provided_fields"), ["date"])
+        self.assertIn("suggestion", result)
+
+    def test_create_document_generic_exception_does_not_crash_on_translation(self):
+        """Regression guard: the local `_, _, fields_part = ...` shadow bug.
+
+        `_` is the translation function imported at module scope. Any local
+        `_ = ...` inside execute() makes Python treat `_` as a function-local
+        for the entire body, so the later `_("Document Creation Error")` call
+        inside frappe.log_error raised UnboundLocalError on paths that didn't
+        reach the local assignment first (e.g. the generic Exception branch
+        triggered by an invalid Link reference, not by MandatoryError).
+
+        Triggering: pass an invalid `reference_type` link value to ToDo. This
+        raises a LinkValidationError (subclass of ValidationError, not
+        MandatoryError), routes through the generic `except Exception`, and
+        attempts to call `_(\"...\")` for log_error. The test asserts the call
+        completes and returns a structured dict, never an UnboundLocalError.
+        """
+        from frappe_assistant_core.plugins.core.tools.create_document import DocumentCreate
+
+        result = DocumentCreate().execute(
+            {
+                "doctype": "ToDo",
+                "data": {
+                    "description": "regression probe",
+                    "reference_type": "User",
+                    "reference_name": "this-user-definitely-does-not-exist@nowhere.invalid",
+                },
+            }
+        )
+
+        self.assertIsInstance(result, dict)
+        # The call must NOT crash with UnboundLocalError no matter what error
+        # path is taken. If the create somehow succeeded, that's also fine —
+        # the test exists to guard the error path, not to assert a specific
+        # validation outcome.
+        if not result.get("success"):
+            error_msg = str(result.get("error") or "")
+            self.assertNotIn("referenced before assignment", error_msg)
+            self.assertNotIn("UnboundLocalError", error_msg)
+            self.assertIn("error_type", result)
+        else:
+            # Cleanup if create unexpectedly succeeded.
+            try:
+                frappe.delete_doc("ToDo", result["name"], ignore_permissions=True, force=True)
+                frappe.db.commit()
+            except Exception:
+                pass
+
     def test_update_document_rejects_child_doctype(self):
         """Direct updates to a child-table doctype must be rejected with a clear suggestion.
 


### PR DESCRIPTION
## Summary

Follow-up regression fix on top of #172 (already merged). Caught during test review.

PR #172's MandatoryError handler used:

```python
_, _, fields_part = error_msg.partition(": ")
```

Both `_`s are conventional throwaways, but Python sees them as local-variable assignments to the name `_`. That promotes `_` to a function-local for the entire `execute()` body, breaking the later `_("Document Creation Error")` call inside the generic `except Exception` branch with:

```
UnboundLocalError: cannot access local variable '_' where it is not associated with a value
```

The bug only manifests when execution reaches the generic-Exception path (e.g. a `LinkValidationError` from an invalid Link reference). The MandatoryError path itself returned before hitting `_(...)`, which is why the original #165 reproducer (Test 1) still passed but the genuine-missing-field test (Test 2) crashed.

## Fix

Use `error_msg.partition(": ")[2]` instead of unpacking. No `_ = ...` assignment, so the module-level `_` (translation function) stays in scope throughout `execute()`.

## Test plan

- [x] New `test_create_document_mandatory_error_returns_structured_response` — happy path through the MandatoryError branch.
- [x] New `test_create_document_generic_exception_does_not_crash_on_translation` — triggers a `LinkValidationError` to hit the generic `except Exception` branch and asserts the result is a structured dict, not an UnboundLocalError. **Verified to fail without the fix** (raises `UnboundLocalError: cannot access local variable '_' where it is not associated with a value`) and pass with it.
- [x] All 27 tests in `test_document_tools.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)