### PR TITLE
fix: loosen chardet constraint to resolve conflict with Frappe 15.107…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "pypdf>=3.0.0",
     "Pillow>=10.0.0",
     "python-docx>=0.8.11",
-    "chardet~=5.1.0",  # Compatible with frappe ~=5.1.0 requirement
+    "chardet>=5.1.0,<6.0.0",  # Compatible with frappe ~=5.1.0 requirement
     "pymupdf>=1.24.0",  # PDF page rendering for Ollama vision OCR
     "python-magic>=0.4.27",
     "beautifulsoup4~=4.12.2",  # Compatible with frappe ~=4.12.2 requirement


### PR DESCRIPTION
Fixes #176

## Problem
FAC had a strict chardet requirement that conflicted with Frappe 15.107+ 
which updated its chardet requirement.

## Fix
Made the chardet requirement more flexible in pyproject.toml so both 
Frappe and FAC resolve to the same version without conflict.

## Testing
Reproduced the issue locally on Frappe 15.107.2 and confirmed the fix 
resolves the conflict.