### PR TITLE
fix: support Allow on Submit fields in update_document

### DIFF
--- a/frappe_assistant_core/core/security_config.py
+++ b/frappe_assistant_core/core/security_config.py
@@ -458,7 +458,9 @@ def is_doctype_accessible(doctype: str, user_role: str) -> bool:
     return doctype not in restricted_doctypes
 
 
-def validate_document_access(user: str, doctype: str, name: str, perm_type: str = "read", data : str = "") -> Dict[str, Any]:
+def validate_document_access(
+    user: str, doctype: str, name: str, perm_type: str = "read", data: str = ""
+) -> Dict[str, Any]:
     """
     Validate if a user can access a specific document with proper Frappe permission checking.
 

--- a/frappe_assistant_core/core/security_config.py
+++ b/frappe_assistant_core/core/security_config.py
@@ -497,10 +497,17 @@ def validate_document_access(user: str, doctype: str, name: str, perm_type: str 
                     doc = frappe.get_doc(doctype, name)
                     if hasattr(doc, "docstatus") and doc.docstatus == 1:
                         if perm_type == "write":
-                            return {
-                                "success": False,
-                                "error": f"Cannot modify submitted document {doctype} {name}",
-                            }
+                            meta = frappe.get_meta(doctype)
+                            non_allowed_fields = []
+                            for field in data.keys():
+                                field_meta = meta.get_field(field)
+                                if not field_meta or not field_meta.allow_on_submit:
+                                    non_allowed_fields.append(field)
+                            if non_allowed_fields:
+                                return {
+                                    "success": False,
+                                    "error": f"Cannot modify submitted document {doctype} {name}",
+                                }
                         elif perm_type == "delete":
                             return {
                                 "success": False,

--- a/frappe_assistant_core/core/security_config.py
+++ b/frappe_assistant_core/core/security_config.py
@@ -458,7 +458,7 @@ def is_doctype_accessible(doctype: str, user_role: str) -> bool:
     return doctype not in restricted_doctypes
 
 
-def validate_document_access(user: str, doctype: str, name: str, perm_type: str = "read") -> Dict[str, Any]:
+def validate_document_access(user: str, doctype: str, name: str, perm_type: str = "read", data : str = "") -> Dict[str, Any]:
     """
     Validate if a user can access a specific document with proper Frappe permission checking.
 

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -260,8 +260,8 @@ class DocumentUpdate(BaseTool):
             return parent_info
 
         # Check allow_on_submit BEFORE security validation for submitted docs
-        current_docstatus_check = frappe.db.get_value(doctype, name, "docstatus")
-        if current_docstatus_check == 1:
+        current_docstatus = frappe.db.get_value(doctype, name, "docstatus")
+        if current_docstatus == 1:
             meta = frappe.get_meta(doctype)
             non_allowed_fields = []
             for field in data.keys():
@@ -272,8 +272,10 @@ class DocumentUpdate(BaseTool):
             if non_allowed_fields:
                 return {
                     "success": False,
-                    "error": f"Cannot modify submitted document {doctype} '{name}'. Fields not allowed on submit: {', '.join(non_allowed_fields)}",
-                    "suggestion": "Only fields marked as 'Allow on Submit' can be updated on submitted documents.",
+                    "error": (
+                        f"Cannot modify submitted document {doctype} '{name}'."
+                        f" Fields not allowed on submit: {', '.join(non_allowed_fields)}"
+                    ),
                 }
 
             # All fields are allow_on_submit — update directly

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -257,39 +257,8 @@ class DocumentUpdate(BaseTool):
                 except Exception:
                     pass
 
-            return parent_info
-
-        # Check allow_on_submit BEFORE security validation for submitted docs
-        current_docstatus = frappe.db.get_value(doctype, name, "docstatus")
-        if current_docstatus == 1:
-            meta = frappe.get_meta(doctype)
-            non_allowed_fields = []
-            for field in data.keys():
-                field_meta = meta.get_field(field)
-                if not field_meta or not field_meta.allow_on_submit:
-                    non_allowed_fields.append(field)
-
-            if non_allowed_fields:
-                return {
-                    "success": False,
-                    "error": (
-                        f"Cannot modify submitted document {doctype} '{name}'."
-                        f" Fields not allowed on submit: {', '.join(non_allowed_fields)}"
-                    ),
-                }
-
-            # All fields are allow_on_submit — update directly
-            for field, value in data.items():
-                frappe.db.set_value(doctype, name, field, value)
-                frappe.db.commit()  # nosemgrep: frappe-manual-commit — required to persist allow_on_submit field updates bypassing the submit lock
-            return {
-                "success": True,
-                "name": name,
-                "doctype": doctype,
-                "updated_fields": list(data.keys()),
-                "docstatus": 1,
-                "message": f"{doctype} '{name}' updated successfully (Allow on Submit fields)",
-            }
+            return parent_info       
+        
 
         # Import security validation
         from frappe_assistant_core.core.security_config import (
@@ -318,6 +287,37 @@ class DocumentUpdate(BaseTool):
             # Enhanced document state validation
             current_docstatus = getattr(doc, "docstatus", 0)
             current_workflow_state = getattr(doc, "workflow_state", None)
+            # Check allow_on_submit BEFORE security validation for submitted docs
+
+            # if current_docstatus == 1:
+            #     meta = frappe.get_meta(doctype)
+            #     non_allowed_fields = []
+            #     for field in data.keys():
+            #         field_meta = meta.get_field(field)
+            #         if not field_meta or not field_meta.allow_on_submit:
+            #             non_allowed_fields.append(field)
+            #     if non_allowed_fields:
+            #         return {
+            #             "success": False,
+            #             "error": (
+            #                 f"Cannot modify submitted document {doctype} '{name}'."
+            #                 f" Fields not allowed on submit: {', '.join(non_allowed_fields)}"
+            #             ),
+            #         }
+
+            #     # All fields are allow_on_submit — update directly
+            #     for field, value in data.items():
+            #         frappe.db.set_value(doctype, name, field, value)
+            #         frappe.db.commit()  # nosemgrep: frappe-manual-commit — required to persist allow_on_submit field updates bypassing the submit lock
+            #     return {
+            #         "success": True,
+            #         "name": name,
+            #         "doctype": doctype,
+            #         "updated_fields": list(data.keys()),
+            #         "docstatus": 1,
+            #         "message": f"{doctype} '{name}' updated successfully (Allow on Submit fields)",
+            #     }
+
             # Check if document is cancelled
             if current_docstatus == 2:
                 result = {

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -257,8 +257,7 @@ class DocumentUpdate(BaseTool):
                 except Exception:
                     pass
 
-            return parent_info       
-        
+            return parent_info
 
         # Import security validation
         from frappe_assistant_core.core.security_config import (
@@ -267,7 +266,7 @@ class DocumentUpdate(BaseTool):
 
         # Validate document access with comprehensive permission checking
         validation_result = validate_document_access(
-            user=frappe.session.user, doctype=doctype, name=name, perm_type="write",data=data
+            user=frappe.session.user, doctype=doctype, name=name, perm_type="write", data=data
         )
 
         if not validation_result["success"]:

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -267,7 +267,7 @@ class DocumentUpdate(BaseTool):
 
         # Validate document access with comprehensive permission checking
         validation_result = validate_document_access(
-            user=frappe.session.user, doctype=doctype, name=name, perm_type="write"
+            user=frappe.session.user, doctype=doctype, name=name, perm_type="write",data=data
         )
 
         if not validation_result["success"]:
@@ -287,36 +287,6 @@ class DocumentUpdate(BaseTool):
             # Enhanced document state validation
             current_docstatus = getattr(doc, "docstatus", 0)
             current_workflow_state = getattr(doc, "workflow_state", None)
-            # Check allow_on_submit BEFORE security validation for submitted docs
-
-            # if current_docstatus == 1:
-            #     meta = frappe.get_meta(doctype)
-            #     non_allowed_fields = []
-            #     for field in data.keys():
-            #         field_meta = meta.get_field(field)
-            #         if not field_meta or not field_meta.allow_on_submit:
-            #             non_allowed_fields.append(field)
-            #     if non_allowed_fields:
-            #         return {
-            #             "success": False,
-            #             "error": (
-            #                 f"Cannot modify submitted document {doctype} '{name}'."
-            #                 f" Fields not allowed on submit: {', '.join(non_allowed_fields)}"
-            #             ),
-            #         }
-
-            #     # All fields are allow_on_submit — update directly
-            #     for field, value in data.items():
-            #         frappe.db.set_value(doctype, name, field, value)
-            #         frappe.db.commit()  # nosemgrep: frappe-manual-commit — required to persist allow_on_submit field updates bypassing the submit lock
-            #     return {
-            #         "success": True,
-            #         "name": name,
-            #         "doctype": doctype,
-            #         "updated_fields": list(data.keys()),
-            #         "docstatus": 1,
-            #         "message": f"{doctype} '{name}' updated successfully (Allow on Submit fields)",
-            #     }
 
             # Check if document is cancelled
             if current_docstatus == 2:

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -279,7 +279,7 @@ class DocumentUpdate(BaseTool):
             # All fields are allow_on_submit — update directly
             for field, value in data.items():
                 frappe.db.set_value(doctype, name, field, value)
-            frappe.db.commit()
+                frappe.db.commit()  # nosemgrep: frappe-manual-commit — required to persist allow_on_submit field updates bypassing the submit lock
             return {
                 "success": True,
                 "name": name,

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -259,6 +259,36 @@ class DocumentUpdate(BaseTool):
 
             return parent_info
 
+        # Check allow_on_submit BEFORE security validation for submitted docs
+        current_docstatus_check = frappe.db.get_value(doctype, name, "docstatus")
+        if current_docstatus_check == 1:
+            meta = frappe.get_meta(doctype)
+            non_allowed_fields = []
+            for field in data.keys():
+                field_meta = meta.get_field(field)
+                if not field_meta or not field_meta.allow_on_submit:
+                    non_allowed_fields.append(field)
+
+            if non_allowed_fields:
+                return {
+                    "success": False,
+                    "error": f"Cannot modify submitted document {doctype} '{name}'. Fields not allowed on submit: {', '.join(non_allowed_fields)}",
+                    "suggestion": "Only fields marked as 'Allow on Submit' can be updated on submitted documents.",
+                }
+
+            # All fields are allow_on_submit — update directly
+            for field, value in data.items():
+                frappe.db.set_value(doctype, name, field, value)
+            frappe.db.commit()
+            return {
+                "success": True,
+                "name": name,
+                "doctype": doctype,
+                "updated_fields": list(data.keys()),
+                "docstatus": 1,
+                "message": f"{doctype} '{name}' updated successfully (Allow on Submit fields)",
+            }
+
         # Import security validation
         from frappe_assistant_core.core.security_config import (
             validate_document_access,
@@ -286,18 +316,6 @@ class DocumentUpdate(BaseTool):
             # Enhanced document state validation
             current_docstatus = getattr(doc, "docstatus", 0)
             current_workflow_state = getattr(doc, "workflow_state", None)
-
-            # Check if document is submitted (protection against editing submitted docs)
-            if current_docstatus == 1:
-                result = {
-                    "success": False,
-                    "error": f"Cannot modify submitted document {doctype} '{name}'. Submitted documents are read-only.",
-                    "docstatus": current_docstatus,
-                    "workflow_state": current_workflow_state,
-                    "suggestion": "Use document_get to view the submitted document, or create a new document if needed.",
-                }
-                return result
-
             # Check if document is cancelled
             if current_docstatus == 2:
                 result = {


### PR DESCRIPTION
## Summary
Support updating Allow on Submit fields on submitted documents via update_document tool.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #179

## Checklist
- [x] I have targeted the `develop` branch (not `main`)
- [x] My code follows the existing code style
- [x] I have tested my changes locally

## Prerequisites for Users
To update a field on a submitted document, the field must have `allow_on_submit = 1` enabled. For standard ERPNext fields like `clearance_date`, this needs to be enabled via Property Setter:
1. Go to Property Setter → New
2. Set DocType = `Purchase Invoice` (or relevant DocType)
3. Set Field Name = `clearance_date`
4. Set Property = `allow_on_submit`
5. Set Value = `1`
6. Save and clear cache
