### PR TITLE
feat: warn on silent field overrides in create_document

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/create_document.py
+++ b/frappe_assistant_core/plugins/core/tools/create_document.py
@@ -199,9 +199,41 @@ class DocumentCreate(BaseTool):
                     "next_step": "Use create_document with validate_only=false to actually create the document",
                 }
 
+            # Capture input child-table values for post-save comparison (issue #181)
+            input_child_values = {}
+            for field, value in data.items():
+                if field in table_fields and isinstance(value, list):
+                    input_child_values[field] = value
+
             # Save document
             doc.insert()
 
+
+            # Check for silently overridden field values
+            warnings = []
+            for field, input_rows in input_child_values.items():
+                saved_rows = doc.get(field) or []
+                for idx, input_row in enumerate(input_rows):
+                    if idx >= len(saved_rows):
+                        break
+                    saved_row = saved_rows[idx]
+                    for key, input_val in input_row.items():
+                        saved_val = getattr(saved_row, key, None)
+                        if saved_val is not None and str(saved_val) != str(input_val):
+                            # Skip numeric false positives (1 vs 1.0, 100 vs 100.0)
+                            try:
+                                if float(str(saved_val)) == float(str(input_val)):
+                                    continue
+                            except (ValueError, TypeError):
+                                pass
+                            warnings.append({
+                                "child_table": field,
+                                "row_idx": idx,
+                                "field": key,
+                                "requested": input_val,
+                                "saved": str(saved_val),
+                                "reason": "Value was overridden by ERPNext validation logic",
+                            })
             # Initialize result with basic information
             result = {
                 "success": True,
@@ -252,6 +284,10 @@ class DocumentCreate(BaseTool):
                 ]
 
             # Log successful creation
+            # Add warnings if any fields were silently overridden
+            if warnings:
+                result["warnings"] = warnings
+
             return result
 
         except frappe.MandatoryError as e:

--- a/frappe_assistant_core/plugins/core/tools/create_document.py
+++ b/frappe_assistant_core/plugins/core/tools/create_document.py
@@ -207,8 +207,6 @@ class DocumentCreate(BaseTool):
 
             # Save document
             doc.insert()
-
-
             # Check for silently overridden field values
             warnings = []
             for field, input_rows in input_child_values.items():
@@ -226,14 +224,16 @@ class DocumentCreate(BaseTool):
                                     continue
                             except (ValueError, TypeError):
                                 pass
-                            warnings.append({
-                                "child_table": field,
-                                "row_idx": idx,
-                                "field": key,
-                                "requested": input_val,
-                                "saved": str(saved_val),
-                                "reason": "Value was overridden by ERPNext validation logic",
-                            })
+                            warnings.append(
+                                {
+                                    "child_table": field,
+                                    "row_idx": idx,
+                                    "field": key,
+                                    "requested": input_val,
+                                    "saved": str(saved_val),
+                                    "reason": "Value was overridden by ERPNext validation logic",
+                                }
+                            )
             # Initialize result with basic information
             result = {
                 "success": True,


### PR DESCRIPTION
## Summary
After doc.insert(), compare input child-table values against saved values. 
If ERPNext validation overrides any field, include a warnings array in the 
response so the caller knows what changed.

## Type of Change
- [x] New feature

## Related Issues
Fixes #181

## Checklist
- [x] I have targeted the `develop` branch (not `main`)
- [x] My code follows the existing code style
- [x] I have tested my changes locally


Before fix — success with no indication expense_account was changed ❌

After fix — success with warning:
{
  "warnings": [{
    "field": "expense_account",
    "requested": "Freight and Forwarding Charges - P",
    "saved": "Stock In Hand - P",
    "reason": "Value was overridden by ERPNext validation logic"
  }]
}
✅