### PR TITLE
fix: coerce date strings to date objects when appending child table rows 

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -131,6 +131,7 @@ def _apply_child_table_update(
             # New row in patch mode → append.
             # Coerce date strings to datetime.date to avoid comparison errors in validate()
             from frappe.utils import getdate
+
             meta = frappe.get_meta(child_doctype)
             coerced_row = {}
             for k, v in row.items():

--- a/frappe_assistant_core/plugins/core/tools/update_document.py
+++ b/frappe_assistant_core/plugins/core/tools/update_document.py
@@ -129,7 +129,17 @@ def _apply_child_table_update(
                     "field": field,
                 }
             # New row in patch mode → append.
-            doc.append(field, row)
+            # Coerce date strings to datetime.date to avoid comparison errors in validate()
+            from frappe.utils import getdate
+            meta = frappe.get_meta(child_doctype)
+            coerced_row = {}
+            for k, v in row.items():
+                field_meta = meta.get_field(k)
+                if field_meta and field_meta.fieldtype == "Date" and isinstance(v, str) and v:
+                    coerced_row[k] = getdate(v)
+                else:
+                    coerced_row[k] = v
+            doc.append(field, coerced_row)
             continue
 
         target = existing_by_name.get(row_name)


### PR DESCRIPTION
## Summary
When appending a new child table row with a Date field (e.g. delivery_date 
on Sales Order items), the value was passed as a Python string which caused 
a TypeError during ERPNext validation.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #168

## Checklist
- [x] I have targeted the `develop` branch (not `main`)
- [x] My code follows the existing code style
- [x] I have tested my changes locally
