### PR TITLE
fix: normalize OAuth discovery URLs to use host_name config

### DIFF
--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -201,8 +201,19 @@ def authorization_server_metadata():
     # Get base metadata from Frappe (V16 built-in or V15 fallback)
     metadata = _get_frappe_authorization_server_metadata()
 
+    # Normalize all URLs to use host_name if configured (fixes http -> https issue #156)
+    frappe_url = (frappe.conf.get("host_name") or get_server_url()).rstrip("/")
+    if frappe_url.startswith("http://"):
+        frappe_url = "https://" + frappe_url[len("http://"):]
+
+    metadata["issuer"] = frappe_url + "/"
+    metadata["authorization_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.authorize"
+    metadata["token_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.get_token"
+    metadata["revocation_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.revoke_token"
+    metadata["introspection_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.introspect_token"
+    metadata["userinfo_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.openid_profile"
+
     # Add/override custom service documentation
-    frappe_url = get_server_url()
     metadata["service_documentation"] = "https://github.com/buildswithpaul/Frappe_Assistant_Core"
 
     # Add client_secret_post as an additional auth method (Frappe V16 only has client_secret_basic)

--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -204,13 +204,15 @@ def authorization_server_metadata():
     # Normalize all URLs to use host_name if configured (fixes http -> https issue #156)
     frappe_url = (frappe.conf.get("host_name") or get_server_url()).rstrip("/")
     if frappe_url.startswith("http://"):
-        frappe_url = "https://" + frappe_url[len("http://"):]
+        frappe_url = "https://" + frappe_url[len("http://") :]
 
     metadata["issuer"] = frappe_url + "/"
     metadata["authorization_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.authorize"
     metadata["token_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.get_token"
     metadata["revocation_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.revoke_token"
-    metadata["introspection_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.introspect_token"
+    metadata["introspection_endpoint"] = (
+        f"{frappe_url}/api/method/frappe.integrations.oauth2.introspect_token"
+    )
     metadata["userinfo_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.openid_profile"
 
     # Add/override custom service documentation

--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -27,6 +27,32 @@ import frappe
 from frappe.oauth import get_server_url
 
 
+def _get_public_base_url() -> str:
+    """
+    Resolve the canonical public base URL for OAuth/MCP discovery metadata.
+
+    Resolution order:
+      1. site_config host_name — explicit operator override; used verbatim
+         if it includes a scheme (https://example.com).
+      2. frappe.oauth.get_server_url() — existing behavior (Social Login Key
+         "frappe" base_url, then frappe.request.url).
+      3. If force_https is set in site_config and the result still starts
+         with http://, upgrade to https://. Gated so localhost dev still works.
+
+    Trailing slash is stripped so callers can append /api/method/... safely.
+    """
+    host_name = frappe.conf.get("host_name")
+    if host_name and "://" in host_name:
+        base = host_name
+    else:
+        base = get_server_url()
+
+    if frappe.conf.get("force_https") and base.startswith("http://"):
+        base = "https://" + base[len("http://") :]
+
+    return base.rstrip("/")
+
+
 # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — OpenID Connect Discovery 1.0 mandates unauthenticated access to this endpoint
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def openid_configuration():
@@ -52,7 +78,16 @@ def openid_configuration():
     metadata = frappe.local.response
 
     # Add MCP-required fields that are missing
-    frappe_url = get_server_url()
+    frappe_url = _get_public_base_url()
+    # Override Frappe-inherited URLs with canonical public base URL
+    metadata["issuer"] = frappe_url
+    metadata["authorization_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.authorize"
+    metadata["token_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.get_token"
+    metadata["revocation_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.revoke_token"
+    metadata["introspection_endpoint"] = (
+        f"{frappe_url}/api/method/frappe.integrations.oauth2.introspect_token"
+    )
+    metadata["userinfo_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.openid_profile"
 
     # Add jwks_uri (required by MCP Inspector)
     metadata["jwks_uri"] = f"{frappe_url}/api/method/frappe_assistant_core.api.oauth_discovery.jwks"
@@ -107,7 +142,7 @@ def mcp_discovery():
     """
     from frappe_assistant_core import hooks
 
-    frappe_url = get_server_url()
+    frappe_url = _get_public_base_url()
 
     # Get MCP configuration from settings
     mcp_protocol_version = "2025-06-18"
@@ -151,7 +186,7 @@ def _get_frappe_authorization_server_metadata():
         return _get_authorization_server_metadata()
     except ImportError:
         # Fallback for Frappe V15 - build metadata manually
-        frappe_url = get_server_url()
+        frappe_url = _get_public_base_url()
 
         # Base metadata following RFC 8414
         metadata = {
@@ -201,12 +236,9 @@ def authorization_server_metadata():
     # Get base metadata from Frappe (V16 built-in or V15 fallback)
     metadata = _get_frappe_authorization_server_metadata()
 
-    # Normalize all URLs to use host_name if configured (fixes http -> https issue #156)
-    frappe_url = (frappe.conf.get("host_name") or get_server_url()).rstrip("/")
-    if frappe_url.startswith("http://"):
-        frappe_url = "https://" + frappe_url[len("http://") :]
-
-    metadata["issuer"] = frappe_url + "/"
+    # Normalize all URLs using canonical public base URL (fixes http -> https issue #156)
+    frappe_url = _get_public_base_url()
+    metadata["issuer"] = frappe_url
     metadata["authorization_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.authorize"
     metadata["token_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.get_token"
     metadata["revocation_endpoint"] = f"{frappe_url}/api/method/frappe.integrations.oauth2.revoke_token"
@@ -274,7 +306,7 @@ def protected_resource_metadata():
 
         raise NotFound("Protected resource metadata is not enabled")
 
-    frappe_url = get_server_url()
+    frappe_url = _get_public_base_url()
 
     # Build list of authorization servers
     authorization_servers = [frappe_url]


### PR DESCRIPTION
## Summary
OAuth discovery endpoint was returning http:// URLs even when host_name 
was configured as https://. This breaks hosted OAuth clients like Claude 
that reject non-HTTPS token endpoints.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #156

## Checklist
- [x] I have targeted the `develop` branch (not `main`)
- [x] My code follows the existing code style
- [x] I have tested my changes locally

