### PR TITLE
fix: include child table metadata in get_doctype_info

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/metadata_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/metadata_tools.py
@@ -89,6 +89,21 @@ class MetadataTools:
             raise Exception(f"Unknown metadata tool: {tool_name}")
 
     @staticmethod
+    def _serialize_field(field) -> Dict[str, Any]:
+        """Serialize a DocField row into the shape returned by get_doctype_metadata."""
+        return {
+            "fieldname": field.fieldname,
+            "label": field.label,
+            "fieldtype": field.fieldtype,
+            "options": field.options,
+            "reqd": field.reqd,
+            "read_only": field.read_only,
+            "hidden": field.hidden,
+            "default": field.default,
+            "description": field.description,
+        }
+
+    @staticmethod
     def get_doctype_metadata(doctype: str) -> Dict[str, Any]:
         """Get DocType metadata and field information"""
         try:
@@ -100,40 +115,44 @@ class MetadataTools:
 
             meta = frappe.get_meta(doctype)
 
-            # Build field information
-            fields = []
-            for field in meta.fields:
-                field_info = {
-                    "fieldname": field.fieldname,
-                    "label": field.label,
-                    "fieldtype": field.fieldtype,
-                    "options": field.options,
-                    "reqd": field.reqd,
-                    "read_only": field.read_only,
-                    "hidden": field.hidden,
-                    "default": field.default,
-                    "description": field.description,
-                }
-                fields.append(field_info)
+            fields = [MetadataTools._serialize_field(field) for field in meta.fields]
 
-            # Build link fields information
-            link_fields = []
-            for field in meta.get_link_fields():
-                link_fields.append(
-                    {"fieldname": field.fieldname, "label": field.label, "options": field.options}
-                )
+            link_fields = [
+                {"fieldname": field.fieldname, "label": field.label, "options": field.options}
+                for field in meta.get_link_fields()
+            ]
+
+            # Child tables: include the child DocType's own field metadata so the
+            # caller can build nested row objects without a second tool call (#192).
+            child_tables = []
+            for table_field in meta.get_table_fields():
+                child_doctype = table_field.options
+                child_entry = {
+                    "fieldname": table_field.fieldname,
+                    "label": table_field.label,
+                    "fieldtype": table_field.fieldtype,
+                    "options": child_doctype,
+                    "reqd": table_field.reqd,
+                    "fields": [],
+                }
+                if child_doctype and frappe.db.exists("DocType", child_doctype):
+                    child_meta = frappe.get_meta(child_doctype)
+                    child_entry["fields"] = [MetadataTools._serialize_field(f) for f in child_meta.fields]
+                child_tables.append(child_entry)
 
             return {
                 "success": True,
                 "doctype": doctype,
                 "module": meta.module,
-                "is_submittable": meta.is_submittable,
-                "is_tree": meta.is_tree,
-                "is_single": meta.istable,
+                "is_submittable": bool(meta.is_submittable),
+                "is_tree": bool(meta.is_tree),
+                "is_single": bool(meta.issingle),
+                "is_child_table": bool(meta.istable),
                 "naming_rule": meta.naming_rule,
                 "title_field": meta.title_field,
                 "fields": fields,
                 "link_fields": link_fields,
+                "child_tables": child_tables,
                 "permissions": [p.as_dict() for p in meta.permissions],
             }
 

--- a/frappe_assistant_core/tests/test_metadata_tools.py
+++ b/frappe_assistant_core/tests/test_metadata_tools.py
@@ -110,6 +110,44 @@ class TestMetadataTools(BaseAssistantTest):
     def test_list_doctypes_with_module_filter(self):
         self.skipTest("Module filter test placeholder")
 
+    def test_get_doctype_metadata_includes_child_tables(self):
+        """Regression guard for #192: child tables must be surfaced with their own field metadata."""
+        from frappe_assistant_core.plugins.core.tools.metadata_tools import MetadataTools
+
+        # User ships with at least one Table field ("roles" -> "Has Role") in every Frappe install.
+        result = MetadataTools.get_doctype_metadata("User")
+
+        self.assertTrue(result.get("success"), result)
+        self.assertIn("child_tables", result)
+        child_tables = result["child_tables"]
+        self.assertIsInstance(child_tables, list)
+
+        roles_entry = next((c for c in child_tables if c["fieldname"] == "roles"), None)
+        self.assertIsNotNone(roles_entry, f"Expected 'roles' in child_tables, got {child_tables}")
+        self.assertEqual(roles_entry["options"], "Has Role")
+        self.assertIn(roles_entry["fieldtype"], ("Table", "Table MultiSelect"))
+
+        # Recursive child field metadata must be present so create_document has everything it needs.
+        self.assertTrue(roles_entry["fields"], "Child table 'roles' should expose its own fields")
+        child_field_names = {f["fieldname"] for f in roles_entry["fields"]}
+        self.assertIn("role", child_field_names)
+
+    def test_get_doctype_metadata_distinguishes_single_from_child_table(self):
+        """Regression guard for #192: is_single must use meta.issingle, not meta.istable."""
+        from frappe_assistant_core.plugins.core.tools.metadata_tools import MetadataTools
+
+        # System Settings is a Single doctype (issingle=1, istable=0).
+        single_result = MetadataTools.get_doctype_metadata("System Settings")
+        self.assertTrue(single_result.get("success"), single_result)
+        self.assertTrue(single_result["is_single"])
+        self.assertFalse(single_result["is_child_table"])
+
+        # Has Role is a child table (issingle=0, istable=1).
+        child_result = MetadataTools.get_doctype_metadata("Has Role")
+        self.assertTrue(child_result.get("success"), child_result)
+        self.assertFalse(child_result["is_single"])
+        self.assertTrue(child_result["is_child_table"])
+
 
 class TestMetadataToolsIntegration(BaseAssistantTest):
     """Integration tests for metadata tools"""


### PR DESCRIPTION
## Summary

`get_doctype_info` returned only top-level fields, so callers hitting `create_document` for a parent doctype (Sales Order, Purchase Order, etc.) had no way to discover the child DocType's own fields — and ended up creating the parent with empty child tables. `create_document`'s own description ([create_document.py:44](https://github.com/buildswithpaul/Frappe_Assistant_Core/blob/develop/frappe_assistant_core/plugins/core/tools/create_document.py#L44)) already tells the model *"First use get_doctype_info to understand the DocType structure, identify required fields and child tables"* — so the gap left the documented workflow broken.

This PR:

1. **Adds a `child_tables` list to the response** — one entry per `Table` / `Table MultiSelect` field, including each child DocType's full field metadata (same shape as the parent `fields` array). Callers now have everything they need in a single tool call.
2. **Fixes `is_single`**, which was reading `meta.istable` (child-table flag) instead of `meta.issingle`. Adds a separate `is_child_table` key so the two concepts stop being conflated.

### Response shape (additions only)

```json
{
  "is_single": false,
  "is_child_table": false,
  "child_tables": [
    {
      "fieldname": "items",
      "label": "Items",
      "fieldtype": "Table",
      "options": "Sales Order Item",
      "reqd": 1,
      "fields": [
        {"fieldname": "item_code", "fieldtype": "Link", "options": "Item", "reqd": 1, ...},
        {"fieldname": "qty", "fieldtype": "Float", "reqd": 1, ...},
        ...
      ]
    },
    ...
  ]
}
```

## Type of Change

- [x] Bug fix
- [x] Feature

## Related Issues

Fixes #192

## Test Plan

- [x] Added `test_get_doctype_metadata_includes_child_tables`: asserts `User.roles` is present in `child_tables` with recursive field metadata (`role` field exposed inside).
- [x] Added `test_get_doctype_metadata_distinguishes_single_from_child_table`: `System Settings` returns `is_single=True, is_child_table=False`; `Has Role` returns `is_single=False, is_child_table=True`.
- [x] `bench --site <site> run-tests --app frappe_assistant_core --module frappe_assistant_core.tests.test_metadata_tools` — 21 tests pass (15 pre-existing placeholders skipped).
- [x] Manual sanity check via console against `Sales Order`: 6 child tables returned with full nested field metadata.

## Checklist

- [x] I have targeted the `develop` branch (not `main`)
- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [x] I have added/updated tests for the change