### PR TITLE
feat: advertise MCP tool annotations from FAC tool category

### DIFF
--- a/frappe_assistant_core/api/fac_endpoint.py
+++ b/frappe_assistant_core/api/fac_endpoint.py
@@ -62,6 +62,12 @@ def _build_tool_registry():
     executing against (issue #197). The set is also genuinely per-user, since
     ``get_available_tools`` filters by the requesting user's permissions.
 
+    Each tool dict carries MCP annotation hints derived from its FAC tool
+    category, so MCP clients (e.g. Claude Desktop) can group tools into
+    Read-only vs Write/delete instead of an undifferentiated "Other tools"
+    bucket. The category is the same one shown/overridable on the FAC admin
+    page (FAC Tool Configuration.tool_category) — single source of truth.
+
     Returns:
         OrderedDict mapping tool name to its MCP tool dict.
     """
@@ -71,17 +77,29 @@ def _build_tool_registry():
     try:
         from frappe_assistant_core.core.tool_registry import get_tool_registry
         from frappe_assistant_core.mcp.tool_adapter import build_tool_dict
+        from frappe_assistant_core.utils.tool_category_detector import category_to_annotations
 
         # Get available tools (respects enabled/disabled state and permissions)
         registry = get_tool_registry()
         available_tools = registry.get_available_tools(user=frappe.session.user)
+
+        # Resolve each tool's category once (honors admin overrides stored on
+        # FAC Tool Configuration; falls back to auto-detection).
+        categories = _resolve_tool_categories(
+            [t.get("name") for t in available_tools if t.get("name")], registry
+        )
 
         for tool_metadata in available_tools:
             tool_name = tool_metadata.get("name")
             if tool_name:
                 tool_instance = registry.get_tool(tool_name)
                 if tool_instance:
-                    registry_dict[tool_name] = build_tool_dict(tool_instance)
+                    tool_dict = build_tool_dict(tool_instance)
+                    annotations = category_to_annotations(categories.get(tool_name, "read_write"))
+                    if annotations:
+                        # Merge with any annotations the tool already declared.
+                        tool_dict["annotations"] = {**(tool_dict.get("annotations") or {}), **annotations}
+                    registry_dict[tool_name] = tool_dict
 
         frappe.logger().info(f"Built {len(registry_dict)} enabled tools for user {frappe.session.user}")
 
@@ -89,6 +107,55 @@ def _build_tool_registry():
         frappe.log_error(title="Tool Import Error", message=f"Error importing tools: {str(e)}")
 
     return registry_dict
+
+
+def _resolve_tool_categories(tool_names: list, registry) -> dict:
+    """
+    Resolve the FAC tool category for each tool name.
+
+    Resolution order per tool:
+      1. Stored ``FAC Tool Configuration.tool_category`` (honors admin override).
+      2. Auto-detected category via ``detect_tool_category`` (no config row yet).
+      3. ``"read_write"`` fallback (maps to no annotation hints — safe default).
+
+    Stored categories are batch-fetched in one query to avoid a DB read per tool.
+
+    Args:
+        tool_names: Tool names to resolve.
+        registry: The tool registry (used to fetch instances for auto-detection).
+
+    Returns:
+        Dict mapping tool name -> category string.
+    """
+    from frappe_assistant_core.utils.tool_category_detector import detect_tool_category
+
+    categories = {}
+
+    # 1. Batch-fetch stored categories.
+    try:
+        rows = frappe.get_all(
+            "FAC Tool Configuration",
+            filters={"tool_name": ["in", tool_names]} if tool_names else {},
+            fields=["tool_name", "tool_category"],
+            ignore_permissions=True,
+        )
+        for row in rows:
+            if row.get("tool_category"):
+                categories[row["tool_name"]] = row["tool_category"]
+    except Exception as e:
+        frappe.logger().warning(f"Could not batch-fetch tool categories: {e}")
+
+    # 2 & 3. Fill gaps via auto-detection, defaulting to read_write.
+    for tool_name in tool_names:
+        if tool_name in categories:
+            continue
+        try:
+            tool_instance = registry.get_tool(tool_name)
+            categories[tool_name] = detect_tool_category(tool_instance) if tool_instance else "read_write"
+        except Exception:
+            categories[tool_name] = "read_write"
+
+    return categories
 
 
 def _authenticate_mcp_request():

--- a/frappe_assistant_core/tests/test_tool_annotations.py
+++ b/frappe_assistant_core/tests/test_tool_annotations.py
@@ -1,0 +1,185 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for MCP tool annotation hints derived from FAC tool categories.
+
+MCP clients (e.g. Claude Desktop) group tools and pick default approval
+behavior from the annotation hints in the tools/list response. FAC previously
+emitted no annotations, so every tool landed in a single "Other tools" bucket.
+The FAC tool category (FAC Tool Configuration.tool_category, admin-overridable)
+is now translated into readOnlyHint / destructiveHint, so the client grouping
+matches the admin page — one source of truth.
+"""
+
+from collections import OrderedDict
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import frappe
+from werkzeug.wrappers import Request, Response
+
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+from frappe_assistant_core.utils.tool_category_detector import category_to_annotations
+
+
+class TestCategoryToAnnotations(BaseAssistantTest):
+    """category_to_annotations maps the 4 FAC categories to MCP hints."""
+
+    def test_read_only(self):
+        self.assertEqual(category_to_annotations("read_only"), {"readOnlyHint": True})
+
+    def test_write(self):
+        self.assertEqual(category_to_annotations("write"), {"readOnlyHint": False})
+
+    def test_read_write(self):
+        self.assertEqual(category_to_annotations("read_write"), {"readOnlyHint": False})
+
+    def test_privileged_is_destructive(self):
+        self.assertEqual(
+            category_to_annotations("privileged"),
+            {"readOnlyHint": False, "destructiveHint": True},
+        )
+
+    def test_dangerous_legacy_alias(self):
+        self.assertEqual(
+            category_to_annotations("dangerous"),
+            {"readOnlyHint": False, "destructiveHint": True},
+        )
+
+    def test_unknown_category_yields_no_hints(self):
+        # Unknown -> empty dict (degrade to "no hint", never a wrong hint).
+        self.assertEqual(category_to_annotations("something_else"), {})
+
+
+class TestResolveToolCategories(BaseAssistantTest):
+    """_resolve_tool_categories prefers the stored (override-able) category."""
+
+    def test_stored_category_wins_over_autodetect(self):
+        from frappe_assistant_core.api import fac_endpoint
+
+        registry = MagicMock()
+        # Auto-detect would say read_only, but the stored config says privileged
+        # (e.g. an admin override). The stored value must win.
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    fac_endpoint.frappe,
+                    "get_all",
+                    return_value=[{"tool_name": "get_document", "tool_category": "privileged"}],
+                )
+            )
+            detect = stack.enter_context(
+                patch(
+                    "frappe_assistant_core.utils.tool_category_detector.detect_tool_category",
+                    return_value="read_only",
+                )
+            )
+
+            result = fac_endpoint._resolve_tool_categories(["get_document"], registry)
+
+        self.assertEqual(result["get_document"], "privileged")
+        detect.assert_not_called()  # no need to auto-detect when stored value exists
+
+    def test_falls_back_to_autodetect_when_no_config_row(self):
+        from frappe_assistant_core.api import fac_endpoint
+
+        registry = MagicMock()
+        registry.get_tool.return_value = MagicMock(name="tool_instance")
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(fac_endpoint.frappe, "get_all", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "frappe_assistant_core.utils.tool_category_detector.detect_tool_category",
+                    return_value="write",
+                )
+            )
+
+            result = fac_endpoint._resolve_tool_categories(["create_document"], registry)
+
+        self.assertEqual(result["create_document"], "write")
+
+    def test_defaults_to_read_write_when_instance_missing(self):
+        from frappe_assistant_core.api import fac_endpoint
+
+        registry = MagicMock()
+        registry.get_tool.return_value = None  # tool instance unavailable
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(fac_endpoint.frappe, "get_all", return_value=[]))
+
+            result = fac_endpoint._resolve_tool_categories(["mystery_tool"], registry)
+
+        self.assertEqual(result["mystery_tool"], "read_write")
+
+
+class TestToolsListEmitsAnnotations(BaseAssistantTest):
+    """The MCP tools/list response must carry the annotation hints so the
+    client can categorize tools."""
+
+    def test_tools_list_includes_annotations(self):
+        from frappe_assistant_core.mcp.server import MCPServer
+
+        server = MCPServer("test")
+        tool_registry = OrderedDict()
+        tool_registry["get_document"] = {
+            "name": "get_document",
+            "description": "Read a document",
+            "inputSchema": {"type": "object", "properties": {}},
+            "annotations": {"readOnlyHint": True},
+            "fn": lambda **kw: {},
+        }
+        tool_registry["delete_document"] = {
+            "name": "delete_document",
+            "description": "Delete a document",
+            "inputSchema": {"type": "object", "properties": {}},
+            "annotations": {"readOnlyHint": False, "destructiveHint": True},
+            "fn": lambda **kw: {},
+        }
+
+        result = server._handle_tools_list({}, tool_registry)
+
+        by_name = {t["name"]: t for t in result["tools"]}
+        self.assertEqual(by_name["get_document"]["annotations"], {"readOnlyHint": True})
+        self.assertEqual(
+            by_name["delete_document"]["annotations"],
+            {"readOnlyHint": False, "destructiveHint": True},
+        )
+
+
+class TestBuildToolRegistryAttachesAnnotations(BaseAssistantTest):
+    """End-to-end: tools built for a request carry category-derived annotations
+    instead of landing unclassified."""
+
+    def test_every_built_tool_has_annotations(self):
+        from frappe_assistant_core.api.fac_endpoint import _build_tool_registry
+
+        registry = _build_tool_registry()
+        self.assertTrue(registry, "expected at least one available tool")
+
+        unclassified = [name for name, td in registry.items() if not td.get("annotations")]
+        self.assertEqual(
+            unclassified,
+            [],
+            f"these tools reached the client with no annotation hints: {unclassified}",
+        )
+
+        # Spot-check known classifications.
+        if "get_document" in registry:
+            self.assertEqual(registry["get_document"]["annotations"].get("readOnlyHint"), True)
+        if "delete_document" in registry:
+            ann = registry["delete_document"]["annotations"]
+            self.assertEqual(ann.get("readOnlyHint"), False)
+            self.assertEqual(ann.get("destructiveHint"), True)

--- a/frappe_assistant_core/utils/tool_category_detector.py
+++ b/frappe_assistant_core/utils/tool_category_detector.py
@@ -234,6 +234,46 @@ def detect_tool_category(tool_instance) -> str:
     return get_detector().detect_category(tool_instance)
 
 
+def category_to_annotations(category: str) -> dict:
+    """
+    Translate a FAC tool category into MCP tool annotation hints.
+
+    MCP clients (e.g. Claude Desktop) group tools and choose default approval
+    behavior from these behavioral hints in the tools/list response. Without
+    them every tool lands in a single "Other tools" bucket. The FAC category
+    (stored on FAC Tool Configuration, admin-overridable) is the single source
+    of truth, so the admin page and the client stay in sync.
+
+    Mapping (per MCP spec; destructiveHint is only meaningful when
+    readOnlyHint is false):
+        read_only  -> {"readOnlyHint": True}                  (Read-only group)
+        write      -> {"readOnlyHint": False}                 (Write/delete group)
+        read_write -> {"readOnlyHint": False}                 (Write/delete group)
+        privileged -> {"readOnlyHint": False, "destructiveHint": True}
+
+    Args:
+        category: One of read_only, write, read_write, privileged
+            ("dangerous" is accepted as a legacy alias for privileged).
+
+    Returns:
+        Dict of MCP annotation hints. Empty dict for an unknown category, so an
+        unrecognized value degrades to "no hints" rather than a wrong hint.
+    """
+    if category == "dangerous":  # legacy alias
+        category = "privileged"
+
+    if category == "read_only":
+        return {"readOnlyHint": True}
+    if category == "write":
+        return {"readOnlyHint": False}
+    if category == "read_write":
+        return {"readOnlyHint": False}
+    if category == "privileged":
+        return {"readOnlyHint": False, "destructiveHint": True}
+
+    return {}
+
+
 def get_category_info(category: str) -> dict:
     """
     Get display information for a category.


### PR DESCRIPTION
## Summary

FAC tools all showed up under a single **"Other tools"** bucket (Needs approval) in Claude Desktop, while other MCP servers (Google Drive, etc.) are split into **Read-only** vs **Write/delete** groups.

### Root cause

MCP clients group tools and pick default approval behavior from the **annotation hints** (`readOnlyHint` / `destructiveHint`) in each tool's `tools/list` entry. FAC emitted none: `BaseTool` has no `annotations` attribute and no tool ever set one, so `_handle_tools_list` always omitted the key. The transport already forwarded annotations when present — only the data source was empty.

### Fix — derive hints from the existing FAC tool category

FAC already classifies every tool into one of four categories on **FAC Tool Configuration.tool_category** (`read_only` / `write` / `read_write` / `privileged`), auto-detected and admin-overridable on the FAC admin page. This PR translates that category — the single source of truth — into MCP hints, so the client grouping stays in sync with the admin page:

| FAC category | MCP hints | Claude group |
|---|---|---|
| `read_only` | `{readOnlyHint: true}` | Read-only tools |
| `write` | `{readOnlyHint: false}` | Write/delete tools |
| `read_write` | `{readOnlyHint: false}` | Write/delete tools |
| `privileged` | `{readOnlyHint: false, destructiveHint: true}` | Write/delete (destructive) |

- `category_to_annotations()` added to `tool_category_detector.py` (co-located with the category logic; accepts the legacy `dangerous` alias; unknown category → no hints, never a wrong one).
- `_build_tool_registry()` resolves each tool's category once via `_resolve_tool_categories()` — stored config/override → auto-detect → `read_write` fallback, batch-fetched in one query — and merges the derived hints onto each tool dict.

No admin-page change: the category is already shown, filterable, overridable, and bulk-toggleable there. This PR just connects that category to what the client sees.

### Verification

Live against the dev site, all 26 tools are now classified (0 unclassified): reads (`get_document`, `list_documents`, `search_*`, `report_list`, …) → read-only; `create_*`/`update_document`/`submit_document`/`run_workflow` → write; `delete_document`/`run_database_query`/`run_python_code` → destructive.

`test_tool_annotations.py` (11 tests): the category→hint mapping, category resolution (stored override wins over auto-detect, fallbacks), `tools/list` emitting the hints, and an end-to-end assertion that every built tool is classified. `test_mcp_concurrency`, `test_document_tools`, `test_search_tools` still pass.

### Note (not in this PR)

`get_pending_approvals` resolves to `read_write` (→ Write/delete group) because it isn't in the detector's `READ_ONLY_TOOLS` list and its perm_type isn't statically detectable. It's a read-only tool, so a follow-up could add it to that list (or an admin can override it today). Left out to keep this PR to the wiring.

### Checklist

- [x] Conventional commit (`feat:`)
- [x] Targets `develop`
- [x] Passes linters (pre-commit: ruff + Frappe semgrep)
- [x] Tests pass
- [x] No DocType changes (no migration needed)
