### PR TITLE
fix: relax beautifulsoup4 pin to support Frappe v16 (#198)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "chardet>=5.1.0,<6.0.0",  # Compatible with frappe ~=5.1.0 requirement
     "pymupdf>=1.24.0",  # PDF page rendering for Ollama vision OCR
     "python-magic>=0.4.27",
-    "beautifulsoup4~=4.12.2",  # Compatible with frappe ~=4.12.2 requirement
+    "beautifulsoup4>=4.12,<5",  # Span Frappe v15 (~=4.12.2) and v16 (~=4.13.5) without forcing a downgrade
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes Observation 1 of #198 — the `beautifulsoup4~=4.12.2` pin downgrades bs4 on Frappe v16 benches.

### Root cause (verified against both Frappe versions)

- Frappe **v15**: `beautifulsoup4~=4.12.2` (locks to 4.12.*)
- Frappe **v16**: `beautifulsoup4~=4.13.5` (locks to 4.13.*)

FAC's `~=4.12.2` intersects with v16's requirement only at 4.12.x, so `bench get-app` downgrades bs4 from 4.13.x to 4.12.x on a v16 bench — exactly the reporter's `pip freeze` evidence (`4.13.5 → 4.12.3`).

### Fix

```diff
-"beautifulsoup4~=4.12.2",  # Compatible with frappe ~=4.12.2 requirement
+"beautifulsoup4>=4.12,<5",  # Span Frappe v15 (~=4.12.2) and v16 (~=4.13.5) without forcing a downgrade
```

`>=4.12,<5` is satisfiable on both v15 (4.12.x) and v16 (4.13.x) and no longer forces a downgrade. FAC uses bs4 only as a transitive convenience and relies on no 4.12-vs-4.13 behavioral difference.

### Scope

This PR covers Observation 1 only. Observation 2 (moving the heavy analytics deps to an optional `[analytics]` extra) is a larger, mildly-breaking packaging change with plugin-loading implications and is tracked separately.

### Checklist

- [x] Conventional commit (`fix:`)
- [x] Targets `develop`
- [x] No code/DocType changes (dependency metadata only)
