### PR TITLE
chore: fix nosemgrep suppressions to use short-form rule IDs

### DIFF
--- a/client_packages/claude-desktop/build.py
+++ b/client_packages/claude-desktop/build.py
@@ -19,7 +19,7 @@ def validate_manifest():
     print("🔍 Validating manifest.json...")
 
     try:
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bundled package manifest next to build.py, not user input
+        # nosemgrep: frappe-security-file-traversal — bundled package manifest next to build.py, not user input
         with open("manifest.json") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:

--- a/client_packages/claude-desktop/validate_manifest.py
+++ b/client_packages/claude-desktop/validate_manifest.py
@@ -20,7 +20,7 @@ def validate_manifest():
 
     # Load and parse JSON
     try:
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bundled package manifest next to this script, not user input
+        # nosemgrep: frappe-security-file-traversal — bundled package manifest next to this script, not user input
         with open("manifest.json") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:

--- a/frappe_assistant_core/api/assistant_api.py
+++ b/frappe_assistant_core/api/assistant_api.py
@@ -208,7 +208,7 @@ def _authenticate_request() -> Optional[str]:
                             return None
 
                         # Set user context for this request
-                        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user authenticated via API key:secret comparison above
+                        # nosemgrep: frappe-setuser — user authenticated via API key:secret comparison above
                         frappe.set_user(str(user))
                         api_logger.debug(f"API key authentication successful: {user}")
                         return str(user)

--- a/frappe_assistant_core/api/fac_endpoint.py
+++ b/frappe_assistant_core/api/fac_endpoint.py
@@ -200,7 +200,7 @@ def _authenticate_mcp_request():
                 raise frappe.AuthenticationError("Token has expired")
 
             # Set the user session
-            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user resolved from validated, non-expired OAuth bearer token
+            # nosemgrep: frappe-setuser — user resolved from validated, non-expired OAuth bearer token
             frappe.set_user(bearer_token.user)
             frappe.logger().info(f"OAuth token validated successfully for user: {bearer_token.user}")
             return bearer_token.user
@@ -267,7 +267,7 @@ def _authenticate_mcp_request():
 
                     if api_secret == decrypted_secret:
                         # Set user context for this request
-                        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — user authenticated via API key:secret comparison above
+                        # nosemgrep: frappe-setuser — user authenticated via API key:secret comparison above
                         frappe.set_user(str(user))
                         frappe.logger().info(f"API key authentication successful for user: {user}")
                         return str(user)

--- a/frappe_assistant_core/api/oauth_discovery.py
+++ b/frappe_assistant_core/api/oauth_discovery.py
@@ -68,7 +68,7 @@ def get_public_base_url() -> str:
     return _get_public_base_url()
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — OpenID Connect Discovery 1.0 mandates unauthenticated access to this endpoint
+# nosemgrep: guest-whitelisted-method — OpenID Connect Discovery 1.0 mandates unauthenticated access to this endpoint
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def openid_configuration():
     """
@@ -134,7 +134,7 @@ def openid_configuration():
         )
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 7517 JWKS endpoint is public by specification
+# nosemgrep: guest-whitelisted-method — RFC 7517 JWKS endpoint is public by specification
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def jwks():
     """
@@ -147,7 +147,7 @@ def jwks():
     return {"keys": []}
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — MCP server discovery is unauthenticated by spec so clients can find the server
+# nosemgrep: guest-whitelisted-method — MCP server discovery is unauthenticated by spec so clients can find the server
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def mcp_discovery():
     """
@@ -223,7 +223,7 @@ def _get_frappe_authorization_server_metadata():
         return metadata
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 8414 OAuth 2.0 Authorization Server Metadata requires unauthenticated access
+# nosemgrep: guest-whitelisted-method — RFC 8414 OAuth 2.0 Authorization Server Metadata requires unauthenticated access
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def authorization_server_metadata():
     """
@@ -297,7 +297,7 @@ def authorization_server_metadata():
     return metadata
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 9728 OAuth 2.0 Protected Resource Metadata requires unauthenticated access
+# nosemgrep: guest-whitelisted-method — RFC 9728 OAuth 2.0 Protected Resource Metadata requires unauthenticated access
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def protected_resource_metadata():
     """

--- a/frappe_assistant_core/api/oauth_registration.py
+++ b/frappe_assistant_core/api/oauth_registration.py
@@ -66,7 +66,7 @@ class OAuth2DynamicClientMetadata(BaseModel):
     jwks: dict | None = None
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 7591 Dynamic Client Registration is unauthenticated by design so new clients can onboard
+# nosemgrep: guest-whitelisted-method — RFC 7591 Dynamic Client Registration is unauthenticated by design so new clients can onboard
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def register_client():
     """

--- a/frappe_assistant_core/api/oauth_token.py
+++ b/frappe_assistant_core/api/oauth_token.py
@@ -33,7 +33,7 @@ from frappe.oauth import generate_json_error_response
 from oauthlib.oauth2 import FatalClientError, OAuth2Error
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method — RFC 6749 §3.2 OAuth token endpoint accepts unauthenticated public clients; credential validation happens inside the handler
+# nosemgrep: guest-whitelisted-method — RFC 6749 §3.2 OAuth token endpoint accepts unauthenticated public clients; credential validation happens inside the handler
 @frappe.whitelist(allow_guest=True)
 def get_token(*args, **kwargs):
     """

--- a/frappe_assistant_core/assistant_core/server.py
+++ b/frappe_assistant_core/assistant_core/server.py
@@ -43,7 +43,7 @@ def get_frappe_port():
 
             if os.path.exists(sites_path) and os.path.isdir(sites_path):
                 if os.path.exists(config_file):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
+                    # nosemgrep: frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
                     with open(config_file) as f:
                         common_config = json.load(f)
                         if "webserver_port" in common_config:

--- a/frappe_assistant_core/plugins/core/tools/report_requirements.py
+++ b/frappe_assistant_core/plugins/core/tools/report_requirements.py
@@ -445,7 +445,7 @@ class ReportRequirements(BaseTool):
             if js_path and os.path.exists(js_path):
                 diag["js_file"]["file_exists"] = True
                 diag["js_file"]["file_readable"] = os.access(js_path, os.R_OK)
-                # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — path built from frappe.get_module_path + scrubbed report metadata, not user input
+                # nosemgrep: frappe-security-file-traversal — path built from frappe.get_module_path + scrubbed report metadata, not user input
                 with open(js_path, encoding="utf-8") as f:
                     js_content = f.read()
                 parsed, note = self._extract_filters_from_js(js_content)

--- a/frappe_assistant_core/plugins/core/tools/report_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/report_tools.py
@@ -738,7 +738,7 @@ class ReportTools:
                 )
 
                 if os.path.exists(js_path):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — path built from frappe.get_app_path + report metadata, not user input
+                    # nosemgrep: frappe-security-file-traversal — path built from frappe.get_app_path + report metadata, not user input
                     with open(js_path, encoding="utf-8") as f:
                         js_content = f.read()
 

--- a/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
+++ b/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
@@ -295,7 +295,7 @@ class ExtractFileContent(BaseTool):
             # 1. Try local filesystem
             file_path = self._get_file_path(file_doc)
             if file_path and os.path.exists(file_path):
-                # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — _get_file_path scopes to /private or /files under the site directory via frappe.get_site_path
+                # nosemgrep: frappe-security-file-traversal — _get_file_path scopes to /private or /files under the site directory via frappe.get_site_path
                 with open(file_path, "rb") as f:
                     return f.read()
 
@@ -565,7 +565,7 @@ class ExtractFileContent(BaseTool):
             )
 
             # Spawn isolated subprocess
-            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
+            # nosemgrep: frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
             proc = subprocess.Popen(
                 [sys.executable, "-m", "frappe_assistant_core.utils.ocr_subprocess"],
                 stdin=subprocess.PIPE,

--- a/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
+++ b/frappe_assistant_core/plugins/data_science/tools/extract_file_content.py
@@ -565,6 +565,7 @@ class ExtractFileContent(BaseTool):
             )
 
             # Spawn isolated subprocess
+            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
             proc = subprocess.Popen(
                 [sys.executable, "-m", "frappe_assistant_core.utils.ocr_subprocess"],
                 stdin=subprocess.PIPE,

--- a/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
+++ b/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
@@ -266,7 +266,7 @@ PRE-LOADED: pd (pandas), np (numpy), frappe, math, datetime, json, re, statistic
         )
 
         # Spawn isolated subprocess
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; user code is passed as JSON over stdin, never as an argument
+        # nosemgrep: frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; user code is passed as JSON over stdin, never as an argument
         proc = subprocess.Popen(
             [sys.executable, "-m", "frappe_assistant_core.utils.code_execution_subprocess"],
             stdin=subprocess.PIPE,

--- a/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
+++ b/frappe_assistant_core/plugins/data_science/tools/run_python_code.py
@@ -266,6 +266,7 @@ PRE-LOADED: pd (pandas), np (numpy), frappe, math, datetime, json, re, statistic
         )
 
         # Spawn isolated subprocess
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; user code is passed as JSON over stdin, never as an argument
         proc = subprocess.Popen(
             [sys.executable, "-m", "frappe_assistant_core.utils.code_execution_subprocess"],
             stdin=subprocess.PIPE,

--- a/frappe_assistant_core/plugins/visualization/plugin.py
+++ b/frappe_assistant_core/plugins/visualization/plugin.py
@@ -244,7 +244,7 @@ class VisualizationPlugin(BasePlugin):
             for template_file in template_files:
                 template_path = os.path.join(template_dir, template_file)
                 if os.path.exists(template_path):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
+                    # nosemgrep: frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
                     with open(template_path) as f:
                         template_data = json.load(f)
                         loaded_templates.append(template_data["name"])

--- a/frappe_assistant_core/plugins/visualization/plugin_registry.py
+++ b/frappe_assistant_core/plugins/visualization/plugin_registry.py
@@ -272,7 +272,7 @@ class VisualizationPlugin(BasePlugin):
             for template_file in template_files:
                 template_path = os.path.join(template_dir, template_file)
                 if os.path.exists(template_path):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
+                    # nosemgrep: frappe-security-file-traversal — template_dir is derived from __file__ and template_file is an allow-listed constant
                     with open(template_path) as f:
                         template_data = json.load(f)
                         loaded_templates.append(template_data["name"])

--- a/frappe_assistant_core/services/config_reader.py
+++ b/frappe_assistant_core/services/config_reader.py
@@ -87,7 +87,7 @@ def get_fallback_redis_config() -> Dict[str, Any]:
 
         for config_path in config_paths:
             try:
-                # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — paths built from bench cwd and fixed config filenames, not user input
+                # nosemgrep: frappe-security-file-traversal — paths built from bench cwd and fixed config filenames, not user input
                 with open(config_path) as f:
                     for line in f:
                         line = line.strip()

--- a/frappe_assistant_core/tests/base_test.py
+++ b/frappe_assistant_core/tests/base_test.py
@@ -38,7 +38,7 @@ class BaseAssistantTest(unittest.TestCase):
 
         # Set default user
         if not hasattr(frappe, "session") or not frappe.session.user:
-            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — test bootstrap; tests run in isolated transaction
+            # nosemgrep: frappe-setuser — test bootstrap; tests run in isolated transaction
             frappe.set_user("Administrator")
 
     def setUp(self):
@@ -48,7 +48,7 @@ class BaseAssistantTest(unittest.TestCase):
 
         # Set test user
         self.test_user = "Administrator"
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — test bootstrap; tests run in isolated transaction
+        # nosemgrep: frappe-setuser — test bootstrap; tests run in isolated transaction
         frappe.set_user(self.test_user)
 
         # Ensure plugins are enabled for testing

--- a/frappe_assistant_core/utils/dashboard.py
+++ b/frappe_assistant_core/utils/dashboard.py
@@ -43,7 +43,7 @@ def get_frappe_port():
 
             if os.path.exists(sites_path) and os.path.isdir(sites_path):
                 if os.path.exists(config_file):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
+                    # nosemgrep: frappe-security-file-traversal — bench-local common_site_config.json discovered by traversal from cwd
                     with open(config_file) as f:
                         common_config = json.load(f)
                         if "webserver_port" in common_config:

--- a/frappe_assistant_core/utils/enhanced_error_handling.py
+++ b/frappe_assistant_core/utils/enhanced_error_handling.py
@@ -478,8 +478,8 @@ class EnhancedErrorHandler:
             audit_doc.insert(ignore_permissions=True)
             # Error path runs while the surrounding request is unwinding; commit
             # explicitly so the audit row survives even if the outer transaction
-            # is rolled back. nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
-            frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+            # is rolled back. nosemgrep: frappe-manual-commit
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit
 
         except Exception as e:
             api_logger.error(f"Failed to log to audit trail: {str(e)}")

--- a/frappe_assistant_core/utils/migration_hooks.py
+++ b/frappe_assistant_core/utils/migration_hooks.py
@@ -323,7 +323,7 @@ def _install_system_prompt_categories():
             frappe.logger("migration_hooks").warning(f"Prompt category data not found at {data_path}")
             return
 
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
+        # nosemgrep: frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
         with open(data_path) as f:
             categories = json.load(f)
 
@@ -413,7 +413,7 @@ def _install_system_prompt_templates():
             frappe.logger("migration_hooks").warning(f"Prompt template data not found at {data_path}")
             return
 
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
+        # nosemgrep: frappe-security-file-traversal — app-bundled seed JSON, path derived from __file__
         with open(data_path) as f:
             templates = json.load(f)
 
@@ -533,7 +533,7 @@ def _install_system_skills():
             frappe.logger("migration_hooks").warning(f"System skills manifest not found at {data_path}")
             return
 
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — app-bundled skills manifest, path derived from __file__
+        # nosemgrep: frappe-security-file-traversal — app-bundled skills manifest, path derived from __file__
         with open(data_path) as f:
             skills_manifest = json.load(f)
 
@@ -569,7 +569,7 @@ def _install_system_skills():
             if content_file:
                 content_path = os.path.join(docs_skills_dir, content_file)
                 if os.path.exists(content_path):
-                    # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — skill markdown under app docs dir, filename from app-controlled manifest
+                    # nosemgrep: frappe-security-file-traversal — skill markdown under app docs dir, filename from app-controlled manifest
                     with open(content_path) as f:
                         content = f.read()
                 else:
@@ -702,7 +702,7 @@ def _install_app_skills():
                 )
                 continue
 
-            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — manifest path from frappe.get_app_path, not user input
+            # nosemgrep: frappe-security-file-traversal — manifest path from frappe.get_app_path, not user input
             with open(manifest_path) as f:
                 skills_manifest = json.load(f)
 
@@ -735,7 +735,7 @@ def _install_app_skills():
                 if content_file and content_dir:
                     content_path = os.path.join(content_dir, content_file)
                     if os.path.exists(content_path):
-                        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal — skill markdown under app-controlled content_dir, filename from app-controlled manifest
+                        # nosemgrep: frappe-security-file-traversal — skill markdown under app-controlled content_dir, filename from app-controlled manifest
                         with open(content_path) as f:
                             content = f.read()
                     else:

--- a/frappe_assistant_core/utils/model_warmup.py
+++ b/frappe_assistant_core/utils/model_warmup.py
@@ -65,7 +65,7 @@ def warm_paddleocr_models():
     proc = None
 
     try:
-        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
+        # nosemgrep: frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
         proc = subprocess.Popen(
             [sys.executable, "-m", "frappe_assistant_core.utils.ocr_subprocess"],
             stdin=subprocess.PIPE,

--- a/frappe_assistant_core/utils/model_warmup.py
+++ b/frappe_assistant_core/utils/model_warmup.py
@@ -65,6 +65,7 @@ def warm_paddleocr_models():
     proc = None
 
     try:
+        # nosemgrep: frappe-semgrep-rules.rules.security.frappe-subprocess-exec — static argv ([sys.executable, "-m", <fixed module>]), shell=False; request is passed as JSON over stdin, never as an argument
         proc = subprocess.Popen(
             [sys.executable, "-m", "frappe_assistant_core.utils.ocr_subprocess"],
             stdin=subprocess.PIPE,

--- a/frappe_assistant_core/utils/user_context.py
+++ b/frappe_assistant_core/utils/user_context.py
@@ -68,7 +68,7 @@ def secure_user_context(username: Optional[str] = None, require_system_manager: 
 
         # Switch user context if different from current
         if target_user != original_user:
-            # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser — context manager restores the previous user in the finally block below
+            # nosemgrep: frappe-setuser — context manager restores the previous user in the finally block below
             frappe.set_user(target_user)
             context_changed = True
 


### PR DESCRIPTION
## What

Two related changes to make our `# nosemgrep` suppressions effective against the Frappe Cloud marketplace audit:

1. **Annotate the 3 `subprocess.Popen` call sites** that lacked a suppression (`run_python_code.py`, `extract_file_content.py`, `model_warmup.py`).
2. **Rewrite every `nosemgrep` directive to the bare/short rule ID** across the app (21 files). Previously they used the fully-qualified `frappe-semgrep-rules.rules.security.*` IDs.

## Why

The Frappe Cloud marketplace audit runs the **bundled** frappe semgrep rules, which match on **short** rule IDs (e.g. `frappe-subprocess-exec`, `frappe-security-file-traversal`) — not the fully-qualified IDs our CI rule source emits. Confirmed by the Frappe team. Our long-form suppressions were therefore silently ignored by the audit scanner, so every reviewed `open()`/`subprocess` call re-surfaced as a finding.

Switching to the short IDs makes the suppressions honored by **both** our CI/pre-commit (still passes — verified) and the marketplace audit.

## Safety

All flagged call sites were reviewed: subprocess calls use static argv `[sys.executable, "-m", <fixed module>]` with `shell=False`, data passed as JSON over stdin; file `open()` paths are framework-scoped (`get_site_path`/`get_module_path`) or fixed config filenames. No behavior change — comments only.

## Notes

- Committed as `chore:` so semantic-release does not treat it as release-worthy.
- Per the Frappe team, subprocess findings get a short manual-review hold (not a code-change requirement) when usage is sound; the approval request will include the file/line/justification details.