### PR TITLE
Feature/attachment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ registry for tools contributed by external apps).
 
 | Category | Tools |
 |---|---|
-| Documents | `get_document`, `list_documents`, `create_document`, `update_document`, `delete_document`, `submit_document` |
+| Documents | `get_document`, `list_documents`, `create_document`, `update_document`, `delete_document`, `submit_document`, `attach_file_to_document`, `list_attachments`, `remove_attachment` |
 | Search | `search`, `search_documents`, `search_doctype`, `search_link`, `fetch` |
 | Reports | `report_list`, `report_requirements`, `generate_report` |
 | Approvals | `get_pending_approvals`, `run_workflow` |

--- a/frappe_assistant_core/plugins/core/plugin.py
+++ b/frappe_assistant_core/plugins/core/plugin.py
@@ -52,7 +52,11 @@ class CorePlugin(BasePlugin):
             "list_documents",
             "delete_document",
             "submit_document",
+            "attach_file_to_document",
+            "list_attachments",
+            "remove_attachment",
             # Search tools
+
             "search_documents",
             "search_doctype",
             "search_link",
@@ -91,6 +95,9 @@ class CorePlugin(BasePlugin):
                 "update": True,
                 "delete": True,
                 "list": True,
+				"attach": True,
+                "list_attachments": True,
+                "remove_attachment": True,
             },
             "search": {"global_search": True, "doctype_search": True, "link_search": True},
             "metadata": {

--- a/frappe_assistant_core/plugins/core/tools/attach_file_to_document.py
+++ b/frappe_assistant_core/plugins/core/tools/attach_file_to_document.py
@@ -1,0 +1,249 @@
+# Stergy FAC Tools - Custom tools for Frappe Assistant Core
+# Copyright (C) 2026 Stergy Cleantech Private Limited
+#
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0),
+# to remain compatible with Frappe Assistant Core.
+
+"""
+Attach File To Document tool for Frappe Assistant Core.
+
+Adds a missing capability to FAC: attaching a file to any existing Frappe /
+ERPNext document. Supports three content sources:
+
+    1. base64 content   -> file bytes supplied inline by the assistant
+    2. existing file_url -> re-attach a file already in the File store
+    3. remote source_url -> download from an http(s) URL and attach
+
+The tool mirrors the conventions of the built-in core write tools
+(create_document, update_document): it subclasses BaseTool, performs a
+dynamic per-document permission check, and returns a structured result.
+"""
+
+import base64
+import binascii
+from typing import Any, Dict
+
+import frappe
+from frappe import _
+
+from frappe_assistant_core.core.base_tool import BaseTool
+
+
+class AttachFileToDocument(BaseTool):
+    """Attach a file to an existing Frappe document."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "attach_file_to_document"
+        self.description = (
+            "Attach a file to an existing Frappe/ERPNext document (e.g. a Purchase "
+            "Invoice, Sales Order, BOM, Quotation or any DocType). The file appears in "
+            "the document's Attachments sidebar. WORKFLOW: provide the target 'doctype' "
+            "and 'name', a 'file_name' (with extension), and exactly ONE content source: "
+            "'content_base64' (inline base64 bytes), 'file_url' (re-attach a file already "
+            "uploaded to this site), or 'source_url' (download from an http/https URL and "
+            "attach). Set 'is_private' to control visibility (defaults to private). The "
+            "current user must have write permission on the target document. Returns the "
+            "created File record name and its file_url."
+        )
+        # Permission is checked dynamically against the target document below,
+        # exactly as the core create_document / update_document tools do.
+        self.requires_permission = None
+        self.category = "write"
+        self.source_app = "stergy_fac_tools"
+
+        self.inputSchema = {
+            "type": "object",
+            "properties": {
+                "doctype": {
+                    "type": "string",
+                    "description": "The target DocType the file should be attached to "
+                    "(e.g. 'Purchase Invoice', 'Sales Order', 'BOM').",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The exact name/ID of the existing target document "
+                    "(e.g. 'PINV-2026-2027-00060').",
+                },
+                "file_name": {
+                    "type": "string",
+                    "description": "File name to store, including extension "
+                    "(e.g. 'gst-invoice.pdf', 'site-photo.jpg').",
+                },
+                "content_base64": {
+                    "type": "string",
+                    "description": "Base64-encoded file content. Use this to attach bytes "
+                    "directly. Provide exactly one of content_base64, file_url or source_url.",
+                },
+                "file_url": {
+                    "type": "string",
+                    "description": "URL of a file already stored on this site "
+                    "(e.g. '/private/files/doc.pdf' or '/files/photo.jpg'). The file is "
+                    "re-attached to the target document without re-uploading its bytes.",
+                },
+                "source_url": {
+                    "type": "string",
+                    "description": "Public http(s) URL to download the file from and then "
+                    "attach. Requires outbound network access from the Frappe server.",
+                },
+                "is_private": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Whether the attachment is private (visible only to users "
+                    "with permission) or public. Defaults to true (private).",
+                },
+            },
+            "required": ["doctype", "name", "file_name"],
+        }
+
+    def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        doctype = arguments.get("doctype")
+        docname = arguments.get("name")
+        file_name = arguments.get("file_name")
+        content_base64 = arguments.get("content_base64")
+        file_url = arguments.get("file_url")
+        source_url = arguments.get("source_url")
+        is_private = arguments.get("is_private", True)
+
+        # --- 1. Exactly one content source -----------------------------------
+        sources = [s for s in (content_base64, file_url, source_url) if s]
+        if len(sources) == 0:
+            return {
+                "success": False,
+                "error": "No content source provided. Supply one of: content_base64, "
+                "file_url, or source_url.",
+                "error_type": "missing_content_source",
+            }
+        if len(sources) > 1:
+            return {
+                "success": False,
+                "error": "Multiple content sources provided. Supply exactly one of: "
+                "content_base64, file_url, or source_url.",
+                "error_type": "ambiguous_content_source",
+            }
+
+        # --- 2. Target document must exist -----------------------------------
+        if not frappe.db.exists(doctype, docname):
+            return {
+                "success": False,
+                "error": f"Target document not found: {doctype} '{docname}'.",
+                "error_type": "document_not_found",
+                "doctype": doctype,
+                "name": docname,
+            }
+
+        # --- 3. Permission check (mirror core write tools) -------------------
+        try:
+            from frappe_assistant_core.core.security_config import validate_document_access
+
+            validation = validate_document_access(
+                user=frappe.session.user,
+                doctype=doctype,
+                name=docname,
+                perm_type="write",
+            )
+            if not validation.get("success"):
+                return validation
+        except ImportError:
+            # Fallback if FAC internals move: use the framework check directly.
+            if not frappe.has_permission(doctype, "write", doc=docname):
+                return {
+                    "success": False,
+                    "error": f"Insufficient permission to attach files to {doctype} "
+                    f"'{docname}'. Write permission is required.",
+                    "error_type": "permission_error",
+                }
+
+        # --- 4. Resolve content ----------------------------------------------
+        content = None
+        if content_base64:
+            try:
+                content = base64.b64decode(content_base64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                return {
+                    "success": False,
+                    "error": f"content_base64 is not valid base64: {e}",
+                    "error_type": "invalid_base64",
+                }
+        elif source_url:
+            if not source_url.lower().startswith(("http://", "https://")):
+                return {
+                    "success": False,
+                    "error": "source_url must start with http:// or https://.",
+                    "error_type": "invalid_source_url",
+                }
+            try:
+                import requests
+
+                resp = requests.get(source_url, timeout=30)
+                resp.raise_for_status()
+                content = resp.content
+            except Exception as e:
+                return {
+                    "success": False,
+                    "error": f"Failed to download from source_url: {e}",
+                    "error_type": "download_failed",
+                    "suggestion": "Verify the URL is reachable and that the Frappe server "
+                    "has outbound network access.",
+                }
+
+        # --- 5. Create the File record (the attachment) ----------------------
+        try:
+            file_payload = {
+                "doctype": "File",
+                "file_name": file_name,
+                "attached_to_doctype": doctype,
+                "attached_to_name": docname,
+                "is_private": 1 if is_private else 0,
+            }
+
+            if content is not None:
+                # Inline bytes or downloaded content: the File controller writes
+                # the bytes to the file store and sets file_url automatically.
+                file_payload["content"] = content
+            else:
+                # Re-attach an existing stored file by its URL. is_private is
+                # inferred from the path so the new record stays consistent.
+                file_payload["file_url"] = file_url
+                file_payload["is_private"] = 1 if file_url.startswith("/private/") else 0
+
+            file_doc = frappe.get_doc(file_payload)
+            file_doc.insert()  # respects permissions; do NOT ignore_permissions
+            frappe.db.commit()
+
+            return {
+                "success": True,
+                "message": f"File '{file_doc.file_name}' attached to {doctype} '{docname}'.",
+                "file": file_doc.name,
+                "file_name": file_doc.file_name,
+                "file_url": file_doc.file_url,
+                "is_private": bool(file_doc.is_private),
+                "file_size": getattr(file_doc, "file_size", None),
+                "attached_to_doctype": doctype,
+                "attached_to_name": docname,
+            }
+
+        except frappe.PermissionError as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "error_type": "permission_error",
+            }
+        except Exception as e:
+            frappe.log_error(
+                title=_("Attach File To Document Error"),
+                message=f"{doctype} {docname} / {file_name}: {str(e)}",
+            )
+            return {
+                "success": False,
+                "error": str(e),
+                "error_type": "attach_failed",
+                "doctype": doctype,
+                "name": docname,
+                "suggestion": "Confirm the file_name has a valid extension and that the "
+                "target document is not cancelled/read-only.",
+            }
+
+
+# Class alias kept consistent with FAC discovery conventions.
+attach_file_to_document = AttachFileToDocument

--- a/frappe_assistant_core/plugins/core/tools/list_attachments.py
+++ b/frappe_assistant_core/plugins/core/tools/list_attachments.py
@@ -1,0 +1,128 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+List Attachments Tool for Core Plugin.
+Lists the files attached to an existing Frappe document.
+"""
+
+from typing import Any, Dict
+
+import frappe
+
+from frappe_assistant_core.core.base_tool import BaseTool
+
+
+class ListAttachments(BaseTool):
+    """
+    Tool for listing files attached to an existing Frappe document.
+
+    Returns each attachment's File record name, file name, URL, visibility,
+    size, and metadata. Read permission on the target document is required.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "list_attachments"
+        self.description = (
+            "List the files attached to an existing Frappe/ERPNext document. Provide the "
+            "target 'doctype' and 'name'; returns each attachment's File record name "
+            "(usable with remove_attachment), file_name, file_url, is_private, file_size, "
+            "and creation metadata. The current user must have read permission on the "
+            "target document."
+        )
+        self.requires_permission = None
+        self.category = "read_only"
+
+        self.inputSchema = {
+            "type": "object",
+            "properties": {
+                "doctype": {
+                    "type": "string",
+                    "description": "The DocType whose attachments to list "
+                    "(e.g. 'Sales Invoice', 'Purchase Order').",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The exact name/ID of the target document.",
+                },
+            },
+            "required": ["doctype", "name"],
+        }
+
+    def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """List attachments of a document."""
+        doctype = arguments.get("doctype")
+        name = arguments.get("name")
+
+        if not frappe.db.exists(doctype, name):
+            return {
+                "success": False,
+                "error": f"Target document not found: {doctype} '{name}'.",
+                "error_type": "document_not_found",
+                "doctype": doctype,
+                "name": name,
+            }
+
+        # Read permission on the target document is the security boundary for
+        # its attachments (File visibility follows the attached_to document).
+        from frappe_assistant_core.core.security_config import validate_document_access
+
+        validation_result = validate_document_access(
+            user=frappe.session.user,
+            doctype=doctype,
+            name=name,
+            perm_type="read",
+        )
+        if not validation_result["success"]:
+            return validation_result
+
+        # Scoped to a single parent the caller can read; this is the correct
+        # access gate for attachments, so a direct File query is appropriate.
+        files = frappe.get_all(
+            "File",
+            filters={
+                "attached_to_doctype": doctype,
+                "attached_to_name": name,
+            },
+            fields=[
+                "name",
+                "file_name",
+                "file_url",
+                "is_private",
+                "file_size",
+                "file_type",
+                "creation",
+                "owner",
+            ],
+            order_by="creation asc",
+        )
+
+        for f in files:
+            f["is_private"] = bool(f.get("is_private"))
+            f["creation"] = str(f.get("creation"))
+
+        return {
+            "success": True,
+            "doctype": doctype,
+            "name": name,
+            "count": len(files),
+            "attachments": files,
+        }
+
+
+# Make sure class name matches file name for discovery
+list_attachments = ListAttachments

--- a/frappe_assistant_core/plugins/core/tools/remove_attachment.py
+++ b/frappe_assistant_core/plugins/core/tools/remove_attachment.py
@@ -1,0 +1,236 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Remove Attachment Tool for Core Plugin.
+Removes a file attached to an existing Frappe document.
+
+This tool only removes files that are attachments (i.e. have an
+attached_to_doctype/attached_to_name). It will not delete standalone File
+records, and it enforces write permission on the parent document.
+"""
+
+from typing import Any, Dict
+
+import frappe
+from frappe import _
+
+from frappe_assistant_core.core.base_tool import BaseTool
+
+
+class RemoveAttachment(BaseTool):
+    """
+    Tool for removing a file attached to an existing Frappe document.
+
+    The attachment can be identified either by its File record name ('file'),
+    or by the target document plus a file_url or file_name. Write permission
+    on the parent document is required. Standalone (non-attachment) File
+    records are never deleted by this tool.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "remove_attachment"
+        self.description = (
+            "Remove (delete) a file attached to an existing Frappe/ERPNext document. "
+            "Identify the attachment EITHER by 'file' (the File record name, e.g. from "
+            "list_attachments) OR by 'doctype' + 'name' plus one of 'file_url' or "
+            "'file_name' to locate it. If more than one attachment matches, the call "
+            "returns the candidates so you can retry with a specific 'file'. The current "
+            "user must have write permission on the parent document. This tool only "
+            "removes files that are attachments; it will not delete standalone files. "
+            "This action is irreversible."
+        )
+        self.requires_permission = None
+        self.category = "privileged"
+
+        self.inputSchema = {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "The File record name (ID) of the attachment to remove, "
+                    "e.g. as returned by list_attachments or attach_file_to_document. The "
+                    "most precise way to target an attachment.",
+                },
+                "doctype": {
+                    "type": "string",
+                    "description": "The parent DocType (used with 'name' to locate the "
+                    "attachment when 'file' is not given).",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The parent document name/ID (used with 'doctype').",
+                },
+                "file_url": {
+                    "type": "string",
+                    "description": "The file_url of the attachment to remove (used with "
+                    "'doctype' and 'name').",
+                },
+                "file_name": {
+                    "type": "string",
+                    "description": "The file_name of the attachment to remove (used with "
+                    "'doctype' and 'name'). Less precise than file_url if duplicates exist.",
+                },
+            },
+            "required": [],
+        }
+
+    def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove an attachment from a document."""
+        file_id = arguments.get("file")
+        doctype = arguments.get("doctype")
+        name = arguments.get("name")
+        file_url = arguments.get("file_url")
+        file_name = arguments.get("file_name")
+
+        # --- Resolve the File record to remove -------------------------------
+        if file_id:
+            if not frappe.db.exists("File", file_id):
+                return {
+                    "success": False,
+                    "error": f"File record not found: '{file_id}'.",
+                    "error_type": "file_not_found",
+                }
+            target_file = file_id
+        else:
+            if not (doctype and name and (file_url or file_name)):
+                return {
+                    "success": False,
+                    "error": "Provide either 'file' (File record name), or 'doctype' and "
+                    "'name' together with 'file_url' or 'file_name'.",
+                    "error_type": "insufficient_identifiers",
+                }
+            if not frappe.db.exists(doctype, name):
+                return {
+                    "success": False,
+                    "error": f"Target document not found: {doctype} '{name}'.",
+                    "error_type": "document_not_found",
+                    "doctype": doctype,
+                    "name": name,
+                }
+
+            filters = {
+                "attached_to_doctype": doctype,
+                "attached_to_name": name,
+            }
+            if file_url:
+                filters["file_url"] = file_url
+            if file_name:
+                filters["file_name"] = file_name
+
+            matches = frappe.get_all(
+                "File",
+                filters=filters,
+                fields=["name", "file_name", "file_url", "is_private"],
+            )
+            if len(matches) == 0:
+                return {
+                    "success": False,
+                    "error": "No matching attachment found on "
+                    f"{doctype} '{name}'.",
+                    "error_type": "attachment_not_found",
+                }
+            if len(matches) > 1:
+                return {
+                    "success": False,
+                    "error": f"{len(matches)} attachments match. Retry with a specific "
+                    "'file' from the candidates.",
+                    "error_type": "ambiguous_attachment",
+                    "candidates": matches,
+                }
+            target_file = matches[0]["name"]
+
+        # --- Confirm it is an attachment and find its parent -----------------
+        file_doc = frappe.get_doc("File", target_file)
+        if not (file_doc.attached_to_doctype and file_doc.attached_to_name):
+            return {
+                "success": False,
+                "error": "This File is not attached to any document. remove_attachment "
+                "only removes attachments and will not delete standalone files.",
+                "error_type": "not_an_attachment",
+                "file": target_file,
+            }
+
+        # Guard against mismatched identifiers when both were supplied.
+        if doctype and file_doc.attached_to_doctype != doctype:
+            return {
+                "success": False,
+                "error": f"Attachment is linked to {file_doc.attached_to_doctype}, not "
+                f"{doctype}.",
+                "error_type": "parent_mismatch",
+            }
+        if name and file_doc.attached_to_name != name:
+            return {
+                "success": False,
+                "error": f"Attachment is linked to '{file_doc.attached_to_name}', not "
+                f"'{name}'.",
+                "error_type": "parent_mismatch",
+            }
+
+        parent_doctype = file_doc.attached_to_doctype
+        parent_name = file_doc.attached_to_name
+
+        # --- Write permission on the parent document -------------------------
+        from frappe_assistant_core.core.security_config import validate_document_access
+
+        validation_result = validate_document_access(
+            user=frappe.session.user,
+            doctype=parent_doctype,
+            name=parent_name,
+            perm_type="write",
+        )
+        if not validation_result["success"]:
+            return validation_result
+
+        removed = {
+            "file": file_doc.name,
+            "file_name": file_doc.file_name,
+            "file_url": file_doc.file_url,
+            "attached_to_doctype": parent_doctype,
+            "attached_to_name": parent_name,
+        }
+
+        # --- Delete (respects permissions; File on_trash unlinks the bytes) --
+        try:
+            frappe.delete_doc("File", file_doc.name)
+            return {
+                "success": True,
+                "message": f"Attachment '{removed['file_name']}' removed from "
+                f"{parent_doctype} '{parent_name}'.",
+                "removed": removed,
+            }
+        except frappe.PermissionError as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "error_type": "permission_error",
+            }
+        except Exception as e:
+            frappe.log_error(
+                title=_("Remove Attachment Error"),
+                message=f"Error removing File '{file_doc.name}' from {parent_doctype} "
+                f"'{parent_name}': {str(e)}",
+            )
+            return {
+                "success": False,
+                "error": str(e),
+                "error_type": "remove_failed",
+            }
+
+
+# Make sure class name matches file name for discovery
+remove_attachment = RemoveAttachment

--- a/frappe_assistant_core/tests/test_attachment_tools.py
+++ b/frappe_assistant_core/tests/test_attachment_tools.py
@@ -1,0 +1,207 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Test suite for the attach_file_to_document tool.
+Exercises registration, input validation, and a real attach round-trip
+against a safe doctype (ToDo).
+"""
+
+import base64
+import unittest
+
+import frappe
+
+from frappe_assistant_core.core.tool_registry import get_tool_registry
+from frappe_assistant_core.plugins.core.tools.attach_file_to_document import (
+    AttachFileToDocument,
+)
+from frappe_assistant_core.plugins.core.tools.list_attachments import ListAttachments
+from frappe_assistant_core.plugins.core.tools.remove_attachment import RemoveAttachment
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+
+class TestAttachFileTool(BaseAssistantTest):
+    """Test the attach_file_to_document tool through the registry and directly."""
+
+    def setUp(self):
+        super().setUp()
+        self.registry = get_tool_registry()
+        # A safe, always-present, attach-friendly doctype.
+        self.todo = frappe.get_doc(
+            {"doctype": "ToDo", "description": "attach_file_to_document test target"}
+        ).insert()
+        self._created_files = []
+
+    def tearDown(self):
+        for file_name in self._created_files:
+            try:
+                frappe.delete_doc("File", file_name, force=True, ignore_permissions=True)
+            except Exception:
+                pass
+        try:
+            frappe.delete_doc("ToDo", self.todo.name, force=True, ignore_permissions=True)
+        except Exception:
+            pass
+        super().tearDown()
+
+    def test_tool_is_registered(self):
+        """The tool should be discoverable through the registry."""
+        tools = self.registry.get_available_tools()
+        tool_names = [tool["name"] for tool in tools]
+        self.assertIn("attach_file_to_document", tool_names)
+
+    def test_requires_a_content_source(self):
+        """Omitting every content source returns a structured error."""
+        result = AttachFileToDocument().execute(
+            {"doctype": "ToDo", "name": self.todo.name, "file_name": "x.txt"}
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "missing_content_source")
+
+    def test_rejects_multiple_content_sources(self):
+        """Supplying more than one content source returns a structured error."""
+        result = AttachFileToDocument().execute(
+            {
+                "doctype": "ToDo",
+                "name": self.todo.name,
+                "file_name": "x.txt",
+                "content_base64": base64.b64encode(b"hi").decode(),
+                "file_url": "/private/files/x.txt",
+            }
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "ambiguous_content_source")
+
+    def test_missing_target_document(self):
+        """A non-existent target document is reported clearly."""
+        result = AttachFileToDocument().execute(
+            {
+                "doctype": "ToDo",
+                "name": "TODO-DOES-NOT-EXIST-999999",
+                "file_name": "x.txt",
+                "content_base64": base64.b64encode(b"hi").decode(),
+            }
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "document_not_found")
+
+    def test_invalid_base64(self):
+        """Malformed base64 content is rejected before any File is created."""
+        result = AttachFileToDocument().execute(
+            {
+                "doctype": "ToDo",
+                "name": self.todo.name,
+                "file_name": "x.txt",
+                "content_base64": "not-valid-base64!!!",
+            }
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "invalid_base64")
+
+    def test_attach_base64_content_roundtrip(self):
+        """Inline base64 content is attached and linked to the target document."""
+        payload = b"Stergy attach test content"
+        result = AttachFileToDocument().execute(
+            {
+                "doctype": "ToDo",
+                "name": self.todo.name,
+                "file_name": "stergy_attach_test.txt",
+                "content_base64": base64.b64encode(payload).decode(),
+                "is_private": True,
+            }
+        )
+        self.assertTrue(result["success"], msg=result)
+        self.assertIn("file", result)
+        self._created_files.append(result["file"])
+
+        file_doc = frappe.get_doc("File", result["file"])
+        self.assertEqual(file_doc.attached_to_doctype, "ToDo")
+        self.assertEqual(file_doc.attached_to_name, self.todo.name)
+        self.assertEqual(int(file_doc.is_private), 1)
+
+    # --- helpers ---------------------------------------------------------
+
+    def _attach(self, file_name, payload=b"data"):
+        """Attach a file to the test ToDo and track it for cleanup."""
+        result = AttachFileToDocument().execute(
+            {
+                "doctype": "ToDo",
+                "name": self.todo.name,
+                "file_name": file_name,
+                "content_base64": base64.b64encode(payload).decode(),
+            }
+        )
+        self.assertTrue(result["success"], msg=result)
+        self._created_files.append(result["file"])
+        return result["file"]
+
+    # --- list_attachments ------------------------------------------------
+
+    def test_list_attachments_registered(self):
+        tool_names = [t["name"] for t in self.registry.get_available_tools()]
+        self.assertIn("list_attachments", tool_names)
+
+    def test_list_attachments_returns_attached_file(self):
+        self._attach("listme.txt")
+        result = ListAttachments().execute({"doctype": "ToDo", "name": self.todo.name})
+        self.assertTrue(result["success"], msg=result)
+        self.assertGreaterEqual(result["count"], 1)
+        names = [a["file_name"] for a in result["attachments"]]
+        self.assertIn("listme.txt", names)
+
+    def test_list_attachments_missing_document(self):
+        result = ListAttachments().execute(
+            {"doctype": "ToDo", "name": "TODO-DOES-NOT-EXIST-999999"}
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "document_not_found")
+
+    # --- remove_attachment -----------------------------------------------
+
+    def test_remove_attachment_registered(self):
+        tool_names = [t["name"] for t in self.registry.get_available_tools()]
+        self.assertIn("remove_attachment", tool_names)
+
+    def test_remove_attachment_by_file_id(self):
+        file_id = self._attach("removeme.txt")
+        result = RemoveAttachment().execute({"file": file_id})
+        self.assertTrue(result["success"], msg=result)
+        self.assertFalse(frappe.db.exists("File", file_id))
+        # already gone; drop from cleanup list
+        self._created_files.remove(file_id)
+
+    def test_remove_attachment_by_parent_and_name(self):
+        self._attach("byname.txt")
+        result = RemoveAttachment().execute(
+            {"doctype": "ToDo", "name": self.todo.name, "file_name": "byname.txt"}
+        )
+        self.assertTrue(result["success"], msg=result)
+        self.assertEqual(result["removed"]["file_name"], "byname.txt")
+
+    def test_remove_attachment_insufficient_identifiers(self):
+        result = RemoveAttachment().execute({"doctype": "ToDo"})
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "insufficient_identifiers")
+
+    def test_remove_attachment_not_found(self):
+        result = RemoveAttachment().execute({"file": "FILE-DOES-NOT-EXIST-999999"})
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_type"], "file_not_found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frappe_assistant_core/utils/tool_category_detector.py
+++ b/frappe_assistant_core/utils/tool_category_detector.py
@@ -47,6 +47,8 @@ PRIVILEGED_TOOLS = {
     "query_and_analyze",
     "run_database_query",
     "delete_document",
+    "remove_attachment",
+
 }
 
 # Tools that are always categorized as read_only (hardcoded list)
@@ -54,6 +56,7 @@ READ_ONLY_TOOLS = {
     # Document tools
     "get_document",
     "list_documents",
+    "list_attachments",
     # Search tools
     "search_documents",
     "search_doctype",
@@ -85,6 +88,7 @@ WRITE_TOOLS = {
     "create_document",
     "update_document",
     "submit_document",
+    "attach_file_to_document",
     # Workflow tools
     "run_workflow",
     # Visualization tools (create/modify)


### PR DESCRIPTION
## Summary

Adds three core tools for managing a document's file attachments, filling a gap where FAC could create/update/submit documents but couldn't manage their files. Requested by several users.

| Tool | Category | What it does |
|------|----------|--------------|
| `attach_file_to_document` | write | Attach a file via inline base64, an existing file_url, or a remote source_url; `is_private` controls visibility |
| `list_attachments` | read_only | List the files attached to a document |
| `remove_attachment` | privileged | Remove an attachment by File id, or by parent doctype/name + file_url/file_name |

**Security:** all three enforce permission on the parent document via `validate_document_access` (read for listing, write for attach/remove); File insert/delete run without `ignore_permissions`. Categories are made deterministic in `tool_category_detector` — attach=write, list=read_only, remove=privileged (matching `delete_document`). `remove_attachment` only deletes actual attachments, never standalone files, and guards against parent mismatch.

**Tests:** `tests/test_attachment_tools.py` covers registration, input validation, and an attach → list → remove round-trip against `ToDo`.

A `FAC Tool Configuration` record is auto-created on `bench migrate` via the existing sync, so no manual registry entry is needed.

<!-- What does this PR do and why? Keep it brief. -->

## Type of Change

<!-- Check all that apply -->

- [x] New feature 
- [ ] Bug fix
- [ ] Security fix
- [ ] Improvement / refactor
- [ ] Documentation
- [ ] Breaking change

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Checklist

- [x] I have targeted the `develop` branch (not `main`)
- [ ] My code follows the existing code style
- [ ] I have tested my changes locally (`bench --site <site> run-tests --app frappe_assistant_core`)
- [ ] I have run `bench migrate` and verified it works
- [x] I have added/updated documentation if needed
- [ ] I have added migration patches if introducing new settings with defaults

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant log output -->
