### PR TITLE
fix: resolve composed report filter contracts for every report type (#220)

### DIFF
--- a/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
+++ b/frappe_assistant_core/assistant_core/doctype/assistant_core_settings/assistant_core_settings.py
@@ -164,9 +164,16 @@ class AssistantCoreSettings(Document):
         # Handle MCP API enable/disable
         if self.server_enabled:
             if server_was_enabled or not server.running:
-                # Enable API if it was just enabled or not running
+                # Enable API if it was just enabled or not running.
+                # enqueue_after_commit is required, not cosmetic: the job calls
+                # server.enable(), which re-reads this Single via
+                # frappe.get_single and returns "MCP API is disabled in
+                # settings" if it sees the pre-save value. Without it the job
+                # races the very transaction that enabled the server.
                 frappe.enqueue(
-                    "frappe_assistant_core.assistant_core.server.enable_background_api", queue="short"
+                    "frappe_assistant_core.assistant_core.server.enable_background_api",
+                    queue="short",
+                    enqueue_after_commit=True,
                 )
         else:
             if server_was_enabled and server.running:

--- a/frappe_assistant_core/plugins/core/tools/js_filter_resolver.py
+++ b/frappe_assistant_core/plugins/core/tools/js_filter_resolver.py
@@ -1,0 +1,1329 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Static resolver for query-report filter definitions declared in JavaScript.
+
+Report JS rarely declares a plain ``filters: [...]`` array. The idiomatic
+Frappe/ERPNext shape *composes* it across files: a shared namespace supplies a
+base array through a builder function, and the report appends its own fields
+with ``.push()``. Issue #220.
+
+This module is deliberately **frappe-free** (stdlib only) so the whole
+resolution path is pure string-in / data-out and unit-testable without a site
+or a database. The one capability it cannot provide itself — reading another
+app's JavaScript off disk — is injected as the ``load_shared`` callback.
+
+Design notes
+------------
+Everything here is driven by a small string- and comment-aware scanner rather
+than per-key regexes. That distinction is not cosmetic: regexes over raw JS
+happily read filter definitions out of commented-out code, truncate values at
+an apostrophe inside a double-quoted string, and interleave ``value``/``label``
+pairs into a single flat options list. A scanner that knows where strings and
+comments begin and end removes that entire class of defect at once.
+
+The resolver never guesses. A value it cannot evaluate statically becomes an
+:class:`Unresolved` marker, which surfaces to the caller as an explicit
+``*_source: "runtime"`` hint plus the original expression — never as a silently
+dropped key, and never as a fabricated value.
+"""
+
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+__all__ = ["Unresolved", "Resolution", "resolve_filters", "blank_non_code"]
+
+# Keys we lift out of a filter object. Anything else in the object is ignored.
+_TRUTHY = (1, True, "1", "true", "True")
+
+# Frappe's Select fieldtype accepts a newline-joined string as its option list.
+_NEWLINE_OPTION_FIELDTYPES = ("Select", "Autocomplete")
+
+# Presence of any of these keys means the option list / default is computed by
+# the browser at runtime and cannot be known statically.
+_RUNTIME_OPTION_KEYS = ("get_data", "get_query", "get_options")
+
+_IDENT_RE = re.compile(r"[A-Za-z_$][\w$]*")
+_DOTTED_RE = re.compile(r"[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\Z")
+_NUMBER_RE = re.compile(r"-?(?:0[xX][0-9a-fA-F]+|\d+\.?\d*(?:[eE][-+]?\d+)?|\.\d+)(?![\w$])")
+
+# ``frappe.query_reports["Some Report"]``
+_QUERY_REPORTS_RE = re.compile(r"frappe\s*\.\s*query_reports\s*\[\s*([\"'])(.*?)\1\s*\]")
+
+# ``...["filters"].push(`` / ``....filters.splice(``
+_MUTATION_RE = re.compile(
+    r"""(?:\[\s*["']filters["']\s*\]|\.\s*filters)\s*\.\s*(push|splice|unshift|concat)\s*\("""
+)
+
+# ``...["filters"] = [...]`` / ``....filters = [...]`` assigned post-registration.
+_FILTERS_ASSIGN_RE = re.compile(r"""(?:\[\s*["']filters["']\s*\]|\.\s*filters)\s*=(?!=)""")
+
+# Filters injected by a server round-trip after the config is declared.
+_RUNTIME_INJECTOR_RE = re.compile(r"\b(add_dimensions|add_inventory_dimensions)\s*\(")
+
+# Mutation of a filter property inside a builder body, e.g. ``x.default = fy``.
+_PROP_ASSIGN_RE = re.compile(r"\.\s*(default|options|reqd|hidden)\s*=(?!=)")
+
+
+class Unresolved:
+    """A JS expression that cannot be evaluated statically.
+
+    Carries the original source text so callers can surface *what* they could
+    not resolve instead of dropping the key and implying it does not exist.
+    """
+
+    __slots__ = ("expr",)
+
+    def __init__(self, expr: str):
+        self.expr = " ".join(str(expr).split())
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return f"Unresolved({self.expr!r})"
+
+    def __eq__(self, other):
+        return isinstance(other, Unresolved) and other.expr == self.expr
+
+    def __hash__(self):
+        return hash(("Unresolved", self.expr))
+
+    def __bool__(self):
+        return True
+
+
+class Resolution:
+    """Outcome of resolving one report's filter contract.
+
+    ``status`` is the field that matters most to a caller:
+
+    ``resolved``
+        Filters were found and parsed.
+    ``no_filters_declared``
+        The report genuinely declares no filters (``filters: []`` or a config
+        object with no ``filters`` key). This is a *successful* answer, not a
+        failure — conflating the two is the defect issue #203 was filed for.
+    ``unresolved``
+        Nothing could be determined. ``notes`` says why.
+    """
+
+    def __init__(self):
+        self.filters: List[Dict[str, Any]] = []
+        self.status: str = "unresolved"
+        self.sources: List[str] = []
+        self.notes: List[str] = []
+        self.partial: bool = False
+        # True when a filter source was found but could not be evaluated. Kept
+        # separate from `notes` so the status tree can never report
+        # "no_filters_declared" for a report whose filters merely failed to
+        # resolve - that would assert the opposite of the truth.
+        self.failed: bool = False
+
+    def note(self, message: str) -> None:
+        if message and message not in self.notes:
+            self.notes.append(message)
+
+    def fail(self, message: str) -> None:
+        """Record a resolution failure, not merely an informational note."""
+        self.failed = True
+        self.note(message)
+
+    def source(self, name: str) -> None:
+        if name and name not in self.sources:
+            self.sources.append(name)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "filters": self.filters,
+            "status": self.status,
+            "sources": self.sources,
+            "notes": self.notes,
+            "partial": self.partial,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Lexical layer — string- and comment-aware
+# ---------------------------------------------------------------------------
+
+
+def scan(source: str) -> Tuple[str, str, bool]:
+    """Split *source* into two same-length views used by the rest of the module.
+
+    Returns ``(sanitized, code, clean)``:
+
+    ``sanitized``
+        Comment bodies **and** string contents blanked to spaces. Brackets and
+        separators inside strings vanish, so balanced-group matching cannot be
+        thrown off by a ``}`` in a message or a ``//`` in a URL.
+    ``code``
+        Comments blanked, string contents **kept**. Needed by the handful of
+        patterns that must read a string literal in a code position — the
+        report name in ``frappe.query_reports["X"]`` and the ``"filters"`` key
+        in ``["filters"].push(...)``.
+    ``clean``
+        False if an unterminated string or block comment was seen, meaning the
+        scan is unreliable and the caller should degrade to a diagnostic rather
+        than trust the result.
+
+    Offsets are preserved in both views, so a match in either indexes correctly
+    into the original source.
+    """
+    sanitized = list(source)
+    code = list(source)
+    i, n = 0, len(source)
+    clean = True
+
+    def blank(target, start, end):
+        for k in range(start, end):
+            if target[k] != "\n":
+                target[k] = " "
+
+    while i < n:
+        ch = source[i]
+
+        if ch == "/" and i + 1 < n and source[i + 1] == "/":
+            end = source.find("\n", i)
+            end = n if end == -1 else end
+            blank(sanitized, i, end)
+            blank(code, i, end)
+            i = end
+
+        elif ch == "/" and i + 1 < n and source[i + 1] == "*":
+            end = source.find("*/", i + 2)
+            if end == -1:
+                clean = False
+                end = n
+            else:
+                end += 2
+            blank(sanitized, i, end)
+            blank(code, i, end)
+            i = end
+
+        elif ch == "`":
+            # Template literals nest: `a${ `b` }c`. Track the ${…} stack so the
+            # closing backtick is found correctly, and blank the whole literal
+            # (substitutions included — they never hold filter definitions).
+            end, terminated = _consume_template(source, i, n)
+            if not terminated:
+                clean = False
+            blank(sanitized, i + 1, max(i + 1, end - 1))
+            i = end
+
+        elif ch in "\"'":
+            quote = ch
+            j = i + 1
+            terminated = False
+            while j < n:
+                if source[j] == "\\":
+                    j += 2
+                    continue
+                if source[j] == quote:
+                    terminated = True
+                    break
+                # An unescaped newline ends a normal string literal.
+                if source[j] == "\n":
+                    break
+                j += 1
+            if not terminated:
+                clean = False
+                j = min(j, n)
+            blank(sanitized, i + 1, min(j, n))
+            i = min(j + 1, n) if terminated else min(j, n)
+
+        elif ch == "/" and _starts_regex(sanitized, i):
+            # A regex literal is neither code nor a string. Left alone, a `/*`
+            # inside one opens a phantom block comment that swallows the report
+            # config, and a quote inside one inverts the two views for the rest
+            # of the file. Blank the body in both views so it can do neither.
+            end, terminated = _consume_regex(source, i, n)
+            if terminated:
+                blank(sanitized, i + 1, end - 1)
+                blank(code, i + 1, end - 1)
+                i = end
+            else:
+                i += 1
+
+        else:
+            i += 1
+
+    return "".join(sanitized), "".join(code), clean
+
+
+# Characters after which a `/` begins a regex literal rather than a division.
+_REGEX_PRECEDERS = set("(,=:[!&|?{};+-*%~^<>")
+_REGEX_KEYWORDS = frozenset(
+    ("return", "typeof", "instanceof", "in", "of", "new", "delete", "void", "case", "do", "else", "yield")
+)
+
+
+def _starts_regex(sanitized: List[str], i: int) -> bool:
+    """Decide whether the ``/`` at *i* opens a regex literal."""
+    j = i - 1
+    while j >= 0 and sanitized[j].isspace():
+        j -= 1
+    if j < 0:
+        return True
+    ch = sanitized[j]
+    if ch in _REGEX_PRECEDERS:
+        return True
+    if ch.isalnum() or ch in "_$":
+        k = j
+        while k >= 0 and (sanitized[k].isalnum() or sanitized[k] in "_$"):
+            k -= 1
+        return "".join(sanitized[k + 1 : j + 1]) in _REGEX_KEYWORDS
+    # A closing bracket, quote or dot means the `/` is division.
+    return False
+
+
+def _consume_regex(source: str, i: int, n: int) -> Tuple[int, bool]:
+    """Return ``(index_past_the_literal_and_flags, terminated)``."""
+    j = i + 1
+    in_class = False
+    while j < n:
+        ch = source[j]
+        if ch == "\\":
+            j += 2
+            continue
+        if ch == "\n":
+            return i + 1, False
+        if in_class:
+            if ch == "]":
+                in_class = False
+        elif ch == "[":
+            in_class = True
+        elif ch == "/":
+            j += 1
+            while j < n and source[j].isalpha():
+                j += 1
+            return j, True
+        j += 1
+    return i + 1, False
+
+
+def _consume_template(source: str, i: int, n: int) -> Tuple[int, bool]:
+    """Return ``(index_past_the_closing_backtick, terminated)`` for a template literal."""
+    stack = ["`"]
+    j = i + 1
+    while j < n and stack:
+        ch = source[j]
+        if ch == "\\":
+            j += 2
+            continue
+        if stack[-1] == "`":
+            if ch == "`":
+                stack.pop()
+            elif ch == "$" and j + 1 < n and source[j + 1] == "{":
+                stack.append("{")
+                j += 2
+                continue
+        else:  # inside a ${ … } substitution
+            if ch == "`":
+                stack.append("`")
+            elif ch == "{":
+                stack.append("{")
+            elif ch == "}":
+                stack.pop()
+            elif ch in "\"'":
+                quote = ch
+                j += 1
+                while j < n and source[j] != quote:
+                    if source[j] == "\\":
+                        j += 1
+                    j += 1
+        j += 1
+    return min(j, n), not stack
+
+
+def blank_non_code(source: str) -> Tuple[str, bool]:
+    """Back-compat shim returning only the fully-sanitized view."""
+    sanitized, _code, clean = scan(source)
+    return sanitized, clean
+
+
+def _in_code(sanitized: str, source: str, index: int) -> bool:
+    """True if *index* is a code position rather than inside a string literal."""
+    return 0 <= index < len(sanitized) and sanitized[index] == source[index]
+
+
+def _skip_trivia(sanitized: str, i: int) -> int:
+    """Advance past whitespace (comments are already blanked)."""
+    n = len(sanitized)
+    while i < n and sanitized[i].isspace():
+        i += 1
+    return i
+
+
+def _match_bracket(sanitized: str, start: int) -> int:
+    """Index of the bracket closing the one at *start*, or -1.
+
+    Operates on sanitized text, so brackets inside strings and comments are
+    invisible and cannot unbalance the count.
+    """
+    pairs = {"{": "}", "[": "]", "(": ")"}
+    opener = sanitized[start]
+    closer = pairs.get(opener)
+    if closer is None:
+        return -1
+    depth = 0
+    for i in range(start, len(sanitized)):
+        c = sanitized[i]
+        if c == opener:
+            depth += 1
+        elif c == closer:
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Value layer — reads JS literals into Python objects
+# ---------------------------------------------------------------------------
+
+
+class _ValueReader:
+    """Reads JS literal values, returning :class:`Unresolved` for expressions."""
+
+    def __init__(self, source: str, sanitized: str):
+        self.src = source
+        self.san = sanitized
+
+    def read(self, i: int) -> Tuple[Any, int]:
+        """Read a value, rejecting literals that are only part of an expression.
+
+        ``default: ["Jan", ..., "Dec"][getMonth()]`` starts with an array
+        literal but its value is one element chosen at runtime. Returning the
+        literal would hand the caller a 12-element list as the default of a
+        scalar Select. Any literal followed by a member access, index or call
+        is therefore surfaced as :class:`Unresolved` instead.
+        """
+        value, end = self._read_atom(i)
+        after = _skip_trivia(self.san, end)
+        if after < len(self.san) and self.san[after] in ".[(":
+            return self._read_expression(i)
+        return value, end
+
+    def _read_atom(self, i: int) -> Tuple[Any, int]:
+        i = _skip_trivia(self.san, i)
+        if i >= len(self.san):
+            return Unresolved(""), i
+        ch = self.san[i]
+
+        if ch == "{":
+            return self._read_object(i)
+        if ch == "[":
+            return self._read_array(i)
+        if ch in "\"'`":
+            return self._read_string(i)
+
+        # ``__("Label")`` is Frappe's translation call. The first argument is
+        # the human-readable label, so treat the call as that string.
+        ident = _IDENT_RE.match(self.san, i)
+        if ident and ident.group(0) == "__":
+            j = _skip_trivia(self.san, ident.end())
+            if j < len(self.san) and self.san[j] == "(":
+                close = _match_bracket(self.san, j)
+                if close != -1:
+                    inner, _ = self.read(j + 1)
+                    if isinstance(inner, str):
+                        return inner, close + 1
+                    return Unresolved(self.src[i : close + 1]), close + 1
+
+        if ident:
+            word = ident.group(0)
+            if word in ("true", "false"):
+                return word == "true", ident.end()
+            if word in ("null", "undefined"):
+                return None, ident.end()
+
+        num = _NUMBER_RE.match(self.san, i)
+        if num and (not ident or num.end() > ident.end()):
+            text = num.group(0)
+            try:
+                if text.lstrip("-")[:2].lower() == "0x":
+                    return int(text, 16), num.end()
+                if "." in text or "e" in text.lower():
+                    return float(text), num.end()
+                return int(text), num.end()
+            except ValueError:
+                pass
+
+        return self._read_expression(i)
+
+    def _read_string(self, i: int) -> Tuple[Any, int]:
+        quote = self.san[i]
+        n = len(self.src)
+
+        if quote == "`":
+            # Templates nest, so their extent must be found the same way scan()
+            # finds it — not by hunting for the next backtick, which stops
+            # inside `a${ `b` }c`.
+            end, _terminated = _consume_template(self.src, i, n)
+            raw = self.src[i + 1 : max(i + 1, end - 1)]
+            if "${" in raw:
+                return Unresolved(self.src[i:end]), end
+            return _unescape(raw), end
+
+        j = i + 1
+        while j < n:
+            if self.src[j] == "\\":
+                j += 2
+                continue
+            if self.src[j] == quote:
+                break
+            if self.src[j] == "\n" and quote != "`":
+                break
+            j += 1
+        raw = self.src[i + 1 : j]
+        if quote == "`" and "${" in raw:
+            return Unresolved(self.src[i : j + 1]), j + 1
+        return _unescape(raw), j + 1
+
+    def _read_array(self, i: int) -> Tuple[Any, int]:
+        close = _match_bracket(self.san, i)
+        if close == -1:
+            return Unresolved(self.src[i:]), len(self.src)
+        items: List[Any] = []
+        j = i + 1
+        while True:
+            j = _skip_trivia(self.san, j)
+            if j >= close:
+                break
+            if self.san[j] in ",;":
+                j += 1
+                continue
+            start = j
+            value, j = self.read(j)
+            if j <= start:  # malformed input; never spin
+                j = start + 1
+                continue
+            items.append(value)
+        return items, close + 1
+
+    def _read_object(self, i: int) -> Tuple[Any, int]:
+        close = _match_bracket(self.san, i)
+        if close == -1:
+            return Unresolved(self.src[i:]), len(self.src)
+        obj: Dict[str, Any] = {}
+        j = i + 1
+        while True:
+            j = _skip_trivia(self.san, j)
+            if j >= close:
+                break
+            if self.san[j] in ",;":
+                j += 1
+                continue
+
+            start = j
+            if self.san[j] in "\"'`":
+                key, j = self._read_string(j)
+            else:
+                ident = _IDENT_RE.match(self.san, j)
+                if not ident:
+                    # Spread element or something exotic — skip to the next
+                    # top-level comma rather than misreading it as a key.
+                    j = self._skip_to_separator(j, close)
+                    if j <= start:  # stray closer; never spin
+                        j = start + 1
+                    continue
+                key, j = ident.group(0), ident.end()
+
+            j = _skip_trivia(self.san, j)
+            if j < close and self.san[j] == "(":
+                # ES6 method shorthand: ``get_options() { ... }``. The body is
+                # not statically evaluable, but the key must still be recorded.
+                end = self._skip_to_separator(j, close)
+                if isinstance(key, str):
+                    obj[key] = Unresolved(self.src[j:end].strip())
+                j = end if end > start else start + 1
+                continue
+            if j >= close or self.san[j] != ":":
+                j = self._skip_to_separator(j, close)
+                if j <= start:
+                    j = start + 1
+                continue
+
+            value, j = self.read(j + 1)
+            if j <= start:
+                j = start + 1
+            if isinstance(key, str):
+                obj[key] = value
+        return obj, close + 1
+
+    def _read_expression(self, i: int) -> Tuple[Any, int]:
+        """Consume an arbitrary expression up to the next top-level separator.
+
+        Always advances. A stray closing bracket makes _skip_to_separator stop
+        where it started; returning that index unchanged would spin the calling
+        array/object loop forever on malformed (or mis-scanned) input.
+        """
+        j = self._skip_to_separator(i, len(self.san))
+        if j <= i:
+            j = i + 1
+        return Unresolved(self.src[i:j]), j
+
+    def _skip_to_separator(self, i: int, limit: int) -> int:
+        """Index of the separator ending the expression that starts at *i*.
+
+        Balanced groups are skipped whole, so the only stoppers seen here are
+        at the expression's own level: a comma, a statement-ending semicolon,
+        or the closer of the group we sit inside. May return *i* itself when
+        *i* already points at a stopper — callers must not rely on progress.
+        """
+        j = i
+        while j < limit:
+            c = self.san[j]
+            if c in "{[(":
+                close = _match_bracket(self.san, j)
+                j = (close + 1) if close != -1 else limit
+                continue
+            if c in "}])" or c in ",;":
+                return j
+            j += 1
+        return limit
+
+
+def _unescape(raw: str) -> str:
+    out = []
+    i, n = 0, len(raw)
+    simple = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f", "v": "\v", "0": "\0"}
+    while i < n:
+        if raw[i] == "\\" and i + 1 < n:
+            nxt = raw[i + 1]
+            if nxt == "u" and raw[i + 2 : i + 3] == "{":
+                end = raw.find("}", i + 3)
+                if end != -1:
+                    try:
+                        out.append(chr(int(raw[i + 3 : end], 16)))
+                        i = end + 1
+                        continue
+                    except (ValueError, OverflowError):
+                        pass
+            elif nxt == "u" and i + 5 < n:
+                try:
+                    point = int(raw[i + 2 : i + 6], 16)
+                except ValueError:
+                    point = None
+                if point is not None:
+                    # Join a surrogate pair, otherwise the result is a lone
+                    # surrogate that cannot be encoded to UTF-8 later.
+                    if 0xD800 <= point <= 0xDBFF and raw[i + 6 : i + 8] == "\\u":
+                        try:
+                            low = int(raw[i + 8 : i + 12], 16)
+                        except ValueError:
+                            low = None
+                        if low is not None and 0xDC00 <= low <= 0xDFFF:
+                            out.append(chr(0x10000 + ((point - 0xD800) << 10) + (low - 0xDC00)))
+                            i += 12
+                            continue
+                    out.append(chr(point))
+                    i += 6
+                    continue
+            elif nxt == "x" and i + 3 < n:
+                try:
+                    out.append(chr(int(raw[i + 2 : i + 4], 16)))
+                    i += 4
+                    continue
+                except ValueError:
+                    pass
+            out.append(simple.get(nxt, nxt))
+            i += 2
+            continue
+        out.append(raw[i])
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation — JS filter object to FAC filter definition
+# ---------------------------------------------------------------------------
+
+
+def _normalize_filter(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert one parsed JS filter object into FAC's filter-definition shape.
+
+    Returns None for entries that are not user-facing filters (layout breaks,
+    objects with no resolvable fieldname).
+    """
+    if not isinstance(obj, dict):
+        return None
+
+    fieldname = obj.get("fieldname")
+    if not isinstance(fieldname, str) or not fieldname.strip():
+        return None
+
+    fieldtype = obj.get("fieldtype")
+    if not isinstance(fieldtype, str):
+        fieldtype = None
+    if fieldtype in ("Break", "Section Break", "Column Break", "HTML"):
+        return None
+
+    out: Dict[str, Any] = {"fieldname": fieldname}
+
+    # ``lable`` is a typo present in shipped ERPNext report JS.
+    label = obj.get("label")
+    if not isinstance(label, str):
+        label = obj.get("lable") if isinstance(obj.get("lable"), str) else None
+    out["label"] = label or fieldname
+
+    if fieldtype:
+        out["fieldtype"] = fieldtype
+
+    options, options_note = _normalize_options(obj, fieldtype)
+    if options is not None:
+        out["options"] = options
+    if options_note:
+        out["options_source"] = "runtime"
+        out["options_expr"] = options_note
+
+    default, default_expr = _normalize_default(obj.get("default"))
+    if default is not None:
+        out["default"] = default
+    if default_expr:
+        out["default_source"] = "runtime"
+        out["default_expr"] = default_expr
+
+    # ``mandatory`` is an accepted alias for ``reqd`` in report JS.
+    reqd = obj.get("reqd")
+    if reqd is None:
+        reqd = obj.get("mandatory")
+    out["required"] = reqd in _TRUTHY
+
+    for key in ("depends_on", "mandatory_depends_on"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            out[key] = value
+
+    if obj.get("hidden") in _TRUTHY:
+        out["hidden"] = True
+
+    if obj.get("wildcard_filter") in _TRUTHY:
+        out["wildcard_filter"] = True
+
+    return out
+
+
+def _normalize_options(obj: Dict[str, Any], fieldtype: Optional[str]):
+    """Return ``(options, runtime_expr)`` for a filter object.
+
+    Handles every option form found in the wild: an array of strings, an array
+    of ``{value, label}`` objects (including numeric values), a mixed array
+    with a leading blank choice, a newline-joined Select string, and a plain
+    DocType name for Link fields.
+    """
+    raw = obj.get("options")
+
+    if raw is None:
+        for key in _RUNTIME_OPTION_KEYS:
+            if key in obj:
+                return None, f"{key}()"
+        return None, None
+
+    if isinstance(raw, Unresolved):
+        return None, raw.expr
+
+    if isinstance(raw, list):
+        values: List[Any] = []
+        for item in raw:
+            if isinstance(item, dict):
+                value = item.get("value")
+                if isinstance(value, Unresolved) or value is None:
+                    continue
+                values.append(value)
+            elif isinstance(item, Unresolved):
+                continue
+            elif item is None:
+                continue
+            elif isinstance(item, str):
+                # A leading "" is Frappe's "no selection" placeholder, not a
+                # selectable value.
+                if item.strip():
+                    values.append(item)
+            else:
+                values.append(item)
+        return values, None
+
+    if isinstance(raw, str):
+        if "\n" in raw:
+            values = [line.strip() for line in raw.split("\n") if line.strip()]
+            return values, None
+        if fieldtype in _NEWLINE_OPTION_FIELDTYPES and not raw.strip():
+            return [], None
+        # Link / MultiSelectList / Dynamic Link: the target DocType.
+        return raw, None
+
+    return None, None
+
+
+def _normalize_default(raw: Any):
+    """Return ``(literal_default, runtime_expression)``."""
+    if raw is None:
+        return None, None
+    if isinstance(raw, Unresolved):
+        return None, raw.expr
+    if isinstance(raw, list):
+        literals = [v for v in raw if not isinstance(v, (Unresolved, dict, list))]
+        if not literals:
+            return None, None
+        # ERPNext writes ``default: ["Fiscal Year"]`` for a scalar Select.
+        return (literals[0] if len(literals) == 1 else literals), None
+    if isinstance(raw, dict):
+        return None, None
+    return raw, None
+
+
+# ---------------------------------------------------------------------------
+# Structural layer — locating and composing the filter array
+# ---------------------------------------------------------------------------
+
+
+def _find_config_assignments(source: str, sanitized: str, code: str, report_name: Optional[str]):
+    """Find ``frappe.query_reports["X"] = ...`` sites.
+
+    Matched against the *code* view so the report name inside the brackets is
+    readable, then validated against the sanitized view so an occurrence inside
+    a string literal is rejected.
+    """
+    results = []
+    for match in _QUERY_REPORTS_RE.finditer(code):
+        if not _in_code(sanitized, source, match.start()):
+            continue
+        after = _skip_trivia(sanitized, match.end())
+        if after < len(sanitized) and sanitized[after] == "=" and sanitized[after + 1 : after + 2] != "=":
+            name = match.group(2)
+            results.append((match, after + 1, report_name is None or name == report_name))
+    return results
+
+
+def _find_function_body(source: str, sanitized: str, name: str):
+    """Return ``(body_start, body_end)`` for a function declared as *name*."""
+    escaped = re.escape(name)
+    patterns = (
+        rf"\bfunction\s+{escaped}\s*\(",
+        rf"\b(?:const|let|var)\s+{escaped}\s*=\s*(?:async\s+)?function\s*\*?\s*\(",
+        rf"\b(?:const|let|var)\s+{escaped}\s*=\s*(?:async\s+)?\(",
+        rf"\b(?:const|let|var)\s+{escaped}\s*=\s*(?:async\s+)?[A-Za-z_$][\w$]*\s*=>",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, sanitized):
+            i = match.end() - 1
+            if sanitized[i] == "(":
+                close = _match_bracket(sanitized, i)
+                if close == -1:
+                    continue
+                i = _skip_trivia(sanitized, close + 1)
+                if sanitized[i : i + 2] == "=>":
+                    i = _skip_trivia(sanitized, i + 2)
+            else:
+                i = _skip_trivia(sanitized, match.end())
+                if sanitized[i : i + 2] == "=>":
+                    i = _skip_trivia(sanitized, i + 2)
+            if i < len(sanitized) and sanitized[i] == "{":
+                end = _match_bracket(sanitized, i)
+                if end != -1:
+                    return i, end
+    return None
+
+
+def _top_level_return(sanitized: str, start: int, end: int) -> int:
+    """Index just past the ``return`` keyword of *this* function body.
+
+    Balanced groups are skipped wholesale, so a ``return`` inside a nested
+    ``get_data``/``get_query`` callback — which real report builders are full
+    of — is never mistaken for the builder's own return statement.
+    """
+    i = start + 1
+    while i < end:
+        ch = sanitized[i]
+        if ch in "{[(":
+            close = _match_bracket(sanitized, i)
+            if close == -1 or close > end:
+                return -1
+            i = close + 1
+            continue
+        if ch == "r" and sanitized.startswith("return", i):
+            before = sanitized[i - 1] if i else " "
+            after = sanitized[i + 6] if i + 6 < len(sanitized) else " "
+            if not (before.isalnum() or before in "_$") and not (after.isalnum() or after in "_$"):
+                return i + 6
+        i += 1
+    return -1
+
+
+def _array_from_function_body(source, sanitized, start, end, result: Resolution):
+    """Extract the filter array a builder function returns."""
+    reader = _ValueReader(source, sanitized)
+    body_san = sanitized[start:end]
+
+    ret = _top_level_return(sanitized, start, end)
+    if ret == -1:
+        return None
+
+    after = _skip_trivia(sanitized, ret)
+    if after < end and sanitized[after] == "[":
+        value, _ = reader.read(after)
+        array_end = _match_bracket(sanitized, after)
+        _note_builder_mutations(source, sanitized, array_end, end, value, result)
+        return value
+
+    ident = _IDENT_RE.match(sanitized, after)
+    if not ident:
+        return None
+
+    var = ident.group(0)
+    decl = re.search(rf"\b(?:let|const|var)\s+{re.escape(var)}\s*=\s*\[", body_san)
+    if not decl:
+        result.fail(f"builder returns '{var}', which is not declared as a literal array in its body")
+        return None
+
+    bracket = start + decl.end() - 1
+    value, _ = reader.read(bracket)
+    array_end = _match_bracket(sanitized, bracket)
+    _note_builder_mutations(source, sanitized, array_end, end, value, result)
+    return value
+
+
+def _note_builder_mutations(source, sanitized, array_end, body_end, array_value, result: Resolution):
+    """Flag filters whose default/options the builder overwrites after declaration.
+
+    ``financial_statements.get_filters()`` fills in fiscal-year defaults with a
+    ``forEach`` after building the literal array. Reporting those fields as
+    "no default" would tell an agent to ask the user for a value the UI always
+    pre-fills.
+    """
+    if array_end == -1 or array_end >= body_end:
+        return
+    if not _PROP_ASSIGN_RE.search(sanitized[array_end:body_end]):
+        return
+
+    fieldnames = set()
+    if isinstance(array_value, list):
+        for item in array_value:
+            if isinstance(item, dict) and isinstance(item.get("fieldname"), str):
+                fieldnames.add(item["fieldname"])
+
+    # String contents are blanked in the sanitized view, so the field names the
+    # mutation targets have to be matched against the original source. Restrict
+    # the match to bracketed array literals — the real shape is
+    # ``["from_fiscal_year", "to_fiscal_year"].includes(x.fieldname)`` — so a
+    # field name merely mentioned in a msgprint or comment is not attributed.
+    tail = source[array_end:body_end]
+    selectors = " ".join(re.findall(r"\[[^\[\]]*\]", tail))
+    touched = sorted(fn for fn in fieldnames if re.search(rf"[\"']{re.escape(fn)}[\"']", selectors))
+    if touched:
+        result.note(
+            "builder assigns values at runtime for: "
+            + ", ".join(touched)
+            + " (treat their default/options as supplied by the UI)"
+        )
+        result._runtime_assigned = touched  # noqa: SLF001 - consumed below
+    else:
+        result.note("builder mutates filter properties at runtime after declaring the array")
+
+
+def _resolve_filters_value(value, source, sanitized, result: Resolution, load_shared, depth=0):
+    """Resolve whatever sits to the right of a ``filters:`` key into a list."""
+    if isinstance(value, list):
+        return value
+
+    if not isinstance(value, Unresolved):
+        return None
+
+    expr = value.expr
+
+    # ``filters: get_filters()`` — a local builder function.
+    # fullmatch, not match: ``base().concat([...])`` starts like a builder call
+    # but the trailing .concat() changes the result, so returning the builder's
+    # array alone would silently drop the concatenated filters.
+    call = re.fullmatch(r"([A-Za-z_$][\w$]*)\s*\([^()]*\)\s*;?", expr)
+    if call:
+        name = call.group(1)
+        body = _find_function_body(source, sanitized, name)
+        if body:
+            array = _array_from_function_body(source, sanitized, body[0], body[1], result)
+            if array is not None:
+                result.source(f"builder:{name}()")
+                return array
+            result.fail(f"builder {name}() found but its returned array could not be read")
+            return None
+        result.fail(f"filters are built by {name}(), which is not defined in this file")
+        return None
+
+    # ``filters: erpnext.some_namespace.filters`` — a cross-file reference.
+    # Strip a trailing semicolon: expressions now stop at `;`, and the raw text
+    # would otherwise defeat the \Z-anchored dotted-identifier test.
+    bare = expr.rstrip().rstrip(";").rstrip()
+    if _DOTTED_RE.match(bare) and depth < 3 and load_shared:
+        namespace = bare.rsplit(".", 1)[0] if bare.endswith(".filters") else bare
+        shared = _resolve_namespace(namespace, result, load_shared, depth + 1)
+        if shared is not None:
+            return shared
+
+    result.fail(f"filters value is not a static array: {expr[:120]}")
+    return None
+
+
+def _resolve_namespace(namespace: str, result: Resolution, load_shared, depth=0):
+    """Load a shared namespace's JS and return its filter array."""
+    if not load_shared or depth > 3:
+        return None
+
+    shared_source = load_shared(namespace)
+    if not shared_source:
+        result.fail(f"shared namespace '{namespace}' referenced but its source was not found")
+        return None
+
+    shared_san, shared_code, clean = scan(shared_source)
+    if not clean:
+        result.note(f"shared namespace '{namespace}' has unbalanced quotes or comments; scan may be partial")
+
+    assign = re.search(rf"{re.escape(namespace)}\s*=\s*\{{", shared_san)
+    if not assign:
+        result.fail(f"shared namespace '{namespace}' source found but no object assignment in it")
+        return None
+
+    reader = _ValueReader(shared_source, shared_san)
+    config, _ = reader.read(assign.end() - 1)
+    if not isinstance(config, dict) or "filters" not in config:
+        result.fail(f"shared namespace '{namespace}' declares no filters")
+        return None
+
+    result.source(f"shared:{namespace}")
+    return _resolve_filters_value(
+        config["filters"], shared_source, shared_san, result, load_shared, depth + 1
+    )
+
+
+def _resolve_config(value, source, sanitized, result: Resolution, load_shared, depth=0):
+    """Resolve a report config value (object or ``$.extend(...)``) to its filters."""
+    if isinstance(value, dict):
+        if "filters" not in value:
+            # A config object that exists and declares no `filters` key means
+            # the report takes no filters. Frappe reads filters from nowhere
+            # else, so this is a definite answer rather than a parse failure.
+            return []
+        return _resolve_filters_value(value["filters"], source, sanitized, result, load_shared, depth)
+
+    if not isinstance(value, Unresolved):
+        return None
+
+    expr = value.expr
+    extend = re.match(r"(?:\$\.extend|jQuery\.extend|Object\.assign)\s*\(", expr)
+    if not extend:
+        if _DOTTED_RE.match(expr):
+            return _resolve_namespace(expr, result, load_shared, depth + 1)
+        result.fail(f"report config is not a static object: {expr[:120]}")
+        return None
+
+    # Read the call arguments. jQuery.extend merges left-to-right, so a later
+    # argument's ``filters`` wins over an earlier one's.
+    arg_san, _arg_code, _arg_clean = scan(expr)
+    open_paren = arg_san.index("(", extend.end() - 1)
+    close = _match_bracket(arg_san, open_paren)
+    if close == -1:
+        result.fail("unbalanced $.extend() call in report config")
+        return None
+
+    reader = _ValueReader(expr, arg_san)
+    args: List[Any] = []
+    i = open_paren + 1
+    while True:
+        i = _skip_trivia(arg_san, i)
+        if i >= close:
+            break
+        if arg_san[i] == ",":
+            i += 1
+            continue
+        arg, i = reader.read(i)
+        args.append(arg)
+
+    # ``$.extend(true, {}, ns)`` — a leading boolean means deep copy.
+    args = [a for a in args if not isinstance(a, bool)]
+
+    resolved = None
+    for arg in args:
+        if isinstance(arg, dict) and "filters" in arg:
+            candidate = _resolve_filters_value(arg["filters"], source, sanitized, result, load_shared, depth)
+            if candidate is not None:
+                resolved = candidate
+        elif isinstance(arg, Unresolved) and _DOTTED_RE.match(arg.expr):
+            candidate = _resolve_namespace(arg.expr, result, load_shared, depth + 1)
+            if candidate is not None:
+                # jQuery.extend merges left to right, so a later argument's
+                # filters override an earlier one's.
+                resolved = candidate
+
+    if resolved is None:
+        result.fail("report config mixes in a namespace whose filters could not be resolved")
+    return resolved
+
+
+# Only member access may separate ``frappe.query_reports["X"]`` from the
+# ``.filters`` it owns — whitespace, dots, brackets, quotes and the word itself.
+_MEMBER_ACCESS_RE = re.compile(r"[\s.\[\]\"']*(?:filters[\s.\[\]\"']*)?\Z")
+
+
+def _owner_lookup(source, sanitized, code):
+    """Build a resolver from a source offset to the report name that owns it."""
+    owners = [
+        (match.end(), match.group(2))
+        for match in _QUERY_REPORTS_RE.finditer(code)
+        if _in_code(sanitized, source, match.start())
+    ]
+
+    def owner_of(position):
+        best = None
+        for end, name in owners:
+            if end <= position and (best is None or end > best[0]):
+                best = (end, name)
+        if best is None:
+            return None
+        # Matched against the sanitized view so a comment mentioning another
+        # report cannot redirect the mutation.
+        return best[1] if _MEMBER_ACCESS_RE.match(sanitized[best[0] : position]) else None
+
+    return owner_of
+
+
+def _collect_mutations(source, sanitized, code, report_name, result: Resolution):
+    """Find ``.filters`` mutations for this report, in source order.
+
+    Each site is attributed by walking back to the nearest preceding
+    ``frappe.query_reports["X"]`` and requiring that only member access
+    separates the two. Substring matching on the report name would let
+    "Sales Register" steal a push belonging to "Sales Register Detail", and a
+    line-based lookback loses a push that prettier wrapped onto its own line.
+    """
+    owner_of = _owner_lookup(source, sanitized, code)
+    mutations = []
+
+    def owned(position):
+        if not report_name:
+            return True
+        owner = owner_of(position)
+        return owner is not None and owner == report_name
+
+    for match in _MUTATION_RE.finditer(code):
+        if not _in_code(sanitized, source, match.start()) or not owned(match.start()):
+            continue
+        open_paren = match.end() - 1
+        close = _match_bracket(sanitized, open_paren)
+        if close == -1:
+            continue
+        mutations.append((match.start(), match.group(1), open_paren, close))
+
+    # ``frappe.query_reports["X"].filters = [...]`` assigns the list after the
+    # config object was registered; without this the report looks filter-less.
+    for match in _FILTERS_ASSIGN_RE.finditer(code):
+        if not _in_code(sanitized, source, match.start()) or not owned(match.start()):
+            continue
+        mutations.append((match.start(), "assign", match.end(), None))
+
+    mutations.sort(key=lambda m: m[0])
+    return mutations
+
+
+def _apply_mutations(filters, mutations, source, sanitized, result: Resolution):
+    """Replay ``push`` mutations; refuse index-based ones.
+
+    ``splice`` is replayed by index into the base array. If any base entry
+    failed to parse, every index shifts and the replay silently removes the
+    wrong filter — two errors in opposite directions with no diagnostic. The
+    honest move is to refuse and say so.
+    """
+    reader = _ValueReader(source, sanitized)
+    by_name = {f.get("fieldname"): i for i, f in enumerate(filters) if isinstance(f, dict)}
+
+    for _pos, kind, open_paren, close in mutations:
+        if kind == "assign":
+            value, _ = reader.read(open_paren)
+            if isinstance(value, list):
+                filters[:] = value
+                by_name = {f.get("fieldname"): n for n, f in enumerate(filters) if isinstance(f, dict)}
+                result.source("assign")
+            else:
+                result.fail("report assigns its filters from an expression that could not be evaluated")
+            continue
+
+        if kind != "push":
+            result.partial = True
+            result.note(
+                f"report mutates its filter list with .{kind}() — that call is not replayed, so this "
+                "list may include a filter the report removes or omit one it reorders"
+            )
+            continue
+
+        i = open_paren + 1
+        added = 0
+        while True:
+            i = _skip_trivia(sanitized, i)
+            if i >= close:
+                break
+            if sanitized[i] == ",":
+                i += 1
+                continue
+            value, i = reader.read(i)
+            for obj in value if isinstance(value, list) else [value]:
+                if not isinstance(obj, dict):
+                    continue
+                name = obj.get("fieldname")
+                if isinstance(name, str) and name in by_name:
+                    filters[by_name[name]] = obj
+                else:
+                    by_name[name] = len(filters)
+                    filters.append(obj)
+                added += 1
+        if added:
+            result.source("push")
+
+    return filters
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_filters(
+    js_text: str,
+    report_name: Optional[str] = None,
+    load_shared: Optional[Callable[[str], Optional[str]]] = None,
+) -> Resolution:
+    """Resolve a report's filter contract from its JavaScript.
+
+    Args:
+        js_text: contents of the report's ``.js`` (or ``Report.javascript``).
+        report_name: the report's exact name, used to attribute
+            ``frappe.query_reports["..."]`` assignments and ``.push()`` calls
+            when one file configures several reports.
+        load_shared: callback resolving a JS namespace such as
+            ``"erpnext.financial_statements"`` to that file's source, or None.
+            Injected so this module stays free of Frappe imports.
+
+    Returns:
+        A :class:`Resolution`. Check ``status`` before ``filters`` — an empty
+        list with ``status == "no_filters_declared"`` is a real answer.
+    """
+    result = Resolution()
+
+    if not js_text or not js_text.strip():
+        result.note("no JavaScript source available")
+        return result
+
+    source = js_text
+    sanitized, code, clean = scan(source)
+    if not clean:
+        result.note("unterminated string or comment in JS; parse may be incomplete")
+        result.partial = True
+
+    reader = _ValueReader(source, sanitized)
+    raw_filters = None
+    config_found = False
+
+    assignments = _find_config_assignments(source, sanitized, code, report_name)
+    for _match, value_start, is_ours in assignments:
+        if not is_ours:
+            continue
+        config_found = True
+        value, _ = reader.read(value_start)
+        raw_filters = _resolve_config(value, source, sanitized, result, load_shared)
+        if raw_filters is not None:
+            result.source("report_js")
+            break
+
+    # A file may configure a report under a name that differs from the Report
+    # doc (or we may have been given no name at all) — retry unfiltered.
+    if raw_filters is None and report_name and assignments and not config_found:
+        for _match, value_start, _is_ours in assignments:
+            value, _ = reader.read(value_start)
+            raw_filters = _resolve_config(value, source, sanitized, result, load_shared)
+            if raw_filters is not None:
+                config_found = True
+                result.source("report_js")
+                break
+
+    if not assignments:
+        # Bare ``filters: [...]`` with no frappe.query_reports wrapper — the
+        # shape used by hand-written Report.javascript snippets.
+        key = re.search(r"[\"']?\bfilters[\"']?\s*:", sanitized)
+        if key:
+            config_found = True
+            value, _ = reader.read(key.end())
+            raw_filters = _resolve_filters_value(value, source, sanitized, result, load_shared)
+            if raw_filters is not None:
+                result.source("report_js")
+        else:
+            result.note("no report configuration found in JS")
+
+    working = list(raw_filters) if raw_filters is not None else []
+    mutations = _collect_mutations(source, sanitized, code, report_name, result)
+    if mutations:
+        config_found = True
+        working = _apply_mutations(working, mutations, source, sanitized, result)
+
+    if _RUNTIME_INJECTOR_RE.search(sanitized):
+        result.note(
+            "report injects additional filters at runtime via add_dimensions()/"
+            "add_inventory_dimensions(); accounting or inventory dimension filters are not listed here"
+        )
+        result.partial = True
+
+    normalized = []
+    for obj in working:
+        filter_def = _normalize_filter(obj)
+        if filter_def:
+            normalized.append(filter_def)
+
+    runtime_assigned = getattr(result, "_runtime_assigned", ())
+    for filter_def in normalized:
+        if filter_def["fieldname"] in runtime_assigned and "default" not in filter_def:
+            filter_def["default_source"] = "runtime"
+
+    result.filters = normalized
+
+    # "no_filters_declared" is a positive assertion — the caller is told the
+    # report genuinely takes none. It is only ever safe to make it when
+    # nothing failed along the way; every other outcome must degrade to
+    # "unresolved" so the diagnostics get read instead of trusted away.
+    if normalized:
+        result.status = "resolved"
+    elif working:
+        # Entries were present but none read as a filter definition (e.g. an
+        # array of factory calls). Emphatically not "this report has none".
+        result.fail("filter entries were found but none could be read as filter definitions")
+        result.status = "unresolved"
+    elif result.failed:
+        result.status = "unresolved"
+    elif raw_filters is not None:
+        result.status = "no_filters_declared"
+        result.note("report explicitly declares an empty filter list")
+    elif not config_found and clean and not result.partial and not _mentions_filters(sanitized):
+        # The JS scanned cleanly and does not mention `filters` anywhere in a
+        # code position — only, at most, inside comments. Frappe registers
+        # filters solely from `frappe.query_reports[...].filters` and the
+        # Report.filters child table, so there is genuinely nothing to find.
+        # Saying so is far more useful than reporting a parse failure.
+        result.status = "no_filters_declared"
+        result.note("report JS declares no filter configuration")
+    else:
+        result.status = "unresolved"
+
+    return result
+
+
+def _mentions_filters(sanitized: str) -> bool:
+    """True if ``filters`` appears in a code position (not only in comments)."""
+    return re.search(r"\bfilters\b", sanitized) is not None

--- a/frappe_assistant_core/plugins/core/tools/js_filter_resolver.py
+++ b/frappe_assistant_core/plugins/core/tools/js_filter_resolver.py
@@ -62,7 +62,13 @@ _DOTTED_RE = re.compile(r"[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\Z")
 _NUMBER_RE = re.compile(r"-?(?:0[xX][0-9a-fA-F]+|\d+\.?\d*(?:[eE][-+]?\d+)?|\.\d+)(?![\w$])")
 
 # ``frappe.query_reports["Some Report"]``
-_QUERY_REPORTS_RE = re.compile(r"frappe\s*\.\s*query_reports\s*\[\s*([\"'])(.*?)\1\s*\]")
+_QUERY_REPORTS_RE = re.compile(
+    r"frappe\s*\.\s*query_reports\s*\[\s*(?:([\"']) (.*?)\1|([A-Za-z_$][\w$]*))\s*\]".replace(" ", "")
+)
+
+# ``const PL_REPORT_NAME = "Profit and Loss Statement";`` — ERPNext v16 binds
+# the report name to a module constant before subscripting query_reports.
+_STRING_CONST_TMPL = r"\b(?:const|let|var)\s+{}\s*=\s*([\"'])(.*?)\1"
 
 # ``...["filters"].push(`` / ``....filters.splice(``
 _MUTATION_RE = re.compile(
@@ -351,6 +357,24 @@ def blank_non_code(source: str) -> Tuple[str, bool]:
     """Back-compat shim returning only the fully-sanitized view."""
     sanitized, _code, clean = scan(source)
     return sanitized, clean
+
+
+def _report_name_at(match, source: str, sanitized: str, code: str) -> Optional[str]:
+    """Report name from a ``frappe.query_reports[...]`` match.
+
+    Returns None when the subscript is an identifier whose string binding
+    cannot be found. Callers treat that as "owner unknown" rather than
+    dropping the site — losing the name is not a reason to lose the filters.
+    """
+    if match.group(2) is not None:
+        return match.group(2)
+    ident = match.group(3)
+    if not ident:
+        return None
+    decl = re.search(_STRING_CONST_TMPL.format(re.escape(ident)), code)
+    if decl and _in_code(sanitized, source, decl.start()):
+        return decl.group(2)
+    return None
 
 
 def _in_code(sanitized: str, source: str, index: int) -> bool:
@@ -803,8 +827,8 @@ def _find_config_assignments(source: str, sanitized: str, code: str, report_name
             continue
         after = _skip_trivia(sanitized, match.end())
         if after < len(sanitized) and sanitized[after] == "=" and sanitized[after + 1 : after + 2] != "=":
-            name = match.group(2)
-            results.append((match, after + 1, report_name is None or name == report_name))
+            name = _report_name_at(match, source, sanitized, code)
+            results.append((match, after + 1, report_name is None or name is None or name == report_name))
     return results
 
 
@@ -1079,7 +1103,7 @@ _MEMBER_ACCESS_RE = re.compile(r"[\s.\[\]\"']*(?:filters[\s.\[\]\"']*)?\Z")
 def _owner_lookup(source, sanitized, code):
     """Build a resolver from a source offset to the report name that owns it."""
     owners = [
-        (match.end(), match.group(2))
+        (match.end(), _report_name_at(match, source, sanitized, code))
         for match in _QUERY_REPORTS_RE.finditer(code)
         if _in_code(sanitized, source, match.start())
     ]
@@ -1114,7 +1138,8 @@ def _collect_mutations(source, sanitized, code, report_name, result: Resolution)
         if not report_name:
             return True
         owner = owner_of(position)
-        return owner is not None and owner == report_name
+        # An unresolvable subscript means the owner is unknown, not foreign.
+        return owner is None or owner == report_name
 
     for match in _MUTATION_RE.finditer(code):
         if not _in_code(sanitized, source, match.start()) or not owned(match.start()):

--- a/frappe_assistant_core/plugins/core/tools/report_requirements.py
+++ b/frappe_assistant_core/plugins/core/tools/report_requirements.py
@@ -19,12 +19,27 @@ Report Requirements Tool for Core Plugin.
 Understand report requirements, structure, and metadata before execution.
 """
 
-from typing import Any, Dict
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 import frappe
 from frappe import _
 
 from frappe_assistant_core.core.base_tool import BaseTool
+from frappe_assistant_core.plugins.core.tools.js_filter_resolver import resolve_filters
+
+# A JS namespace such as ``erpnext.financial_statements``. Anything that does
+# not look like this is never turned into a filesystem lookup.
+_NAMESPACE_RE = re.compile(r"\A[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\Z")
+
+# Guards for the bounded search that locates a shared namespace's source file.
+_JS_SEARCH_MAX_BYTES = 512 * 1024
+_JS_SEARCH_SKIP_DIRS = {"node_modules", "dist", "build", ".git", "__pycache__"}
+
+# Sentinel cached for a namespace that no installed app defines, so the search
+# is not repeated on every call.
+_NAMESPACE_MISS = "\x00miss"
 
 
 class ReportRequirements(BaseTool):
@@ -42,7 +57,7 @@ class ReportRequirements(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "report_requirements"
-        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. NOTE: Report Builder reports are not supported as they are simple DocType list views without business logic."
+        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. Filter definitions are read from the report's stored configuration and JavaScript; where a value is computed in the browser at runtime the response says so via 'default_source'/'options_source' rather than guessing. Check 'filter_discovery_status': 'no_filters_declared' means the report genuinely takes no filters, while 'unresolved' means discovery failed and 'discovery_diagnostics' explains why. NOTE: Report Builder reports store a saved filter configuration rather than a filter contract and are not yet fully supported."
         self.requires_permission = None  # Permission checked dynamically per report
 
         self.inputSchema = {
@@ -126,28 +141,25 @@ class ReportRequirements(BaseTool):
                 if "filter_guidance" in column_result:
                     result["filter_guidance"] = column_result["filter_guidance"]
 
-                # Add filter requirements analysis
-                result["filter_requirements"] = self._analyze_filter_requirements(
-                    report_name, column_result.get("report_type")
-                )
+                # Filter discovery runs for every report type. Gating it to
+                # Script Reports left Query and Custom Reports with no filter
+                # definitions AND no diagnostics — indistinguishable from a
+                # report that genuinely takes none (issue #220).
+                parsed, diagnostics = self._discover_report_filters(report_name, report_doc)
+                result["discovery_diagnostics"] = diagnostics
+                result["filter_discovery_status"] = diagnostics.get("status", "unresolved")
 
-                # For Script Reports, discover filters from multiple sources and
-                # add to main response.
-                if column_result.get("report_type") == "Script Report":
-                    parsed_filters, diagnostics = self._discover_script_report_filters(
-                        report_name, report_doc
+                if parsed is not None:
+                    result["filters_definition"] = parsed["filters"]
+                    result["required_filter_names"] = parsed["required_filters"]
+                    result["optional_filter_names"] = parsed["optional_filters"]
+                    if parsed["conditional_filters"]:
+                        result["conditional_filter_names"] = parsed["conditional_filters"]
+                    result["filter_requirements"] = self._build_requirements_from_parsed_filters(parsed)
+                else:
+                    result["filter_requirements"] = self._generic_filter_guidance(
+                        column_result.get("report_type"), diagnostics
                     )
-                    result["discovery_diagnostics"] = diagnostics
-
-                    if parsed_filters and parsed_filters.get("filters"):
-                        result["filters_definition"] = parsed_filters["filters"]
-                        result["required_filter_names"] = parsed_filters.get("required_filters", [])
-                        result["optional_filter_names"] = parsed_filters.get("optional_filters", [])
-
-                        # Override filter_requirements with parsed data instead of pattern-based guesses
-                        result["filter_requirements"] = self._build_requirements_from_parsed_filters(
-                            parsed_filters
-                        )
 
             # Add comprehensive metadata if requested
             if include_metadata:
@@ -164,168 +176,193 @@ class ReportRequirements(BaseTool):
 
             return {"success": False, "error": str(e)}
 
-    def _build_requirements_from_parsed_filters(self, parsed_filters: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Build filter requirements from parsed filter definitions.
+    # ------------------------------------------------------------------
+    # Filter discovery
+    # ------------------------------------------------------------------
 
-        Args:
-            parsed_filters: Dictionary with 'filters', 'required_filters', 'optional_filters'
+    def _discover_report_filters(self, report_name: str, report_doc) -> Tuple[Optional[Dict], Dict]:
+        """
+        Discover a report's filter contract, recording a diagnostic for every
+        source attempted so an empty result is never silent (issues #203, #220).
+
+        Order (first source that yields an answer wins):
+            1. ``Report.filters`` child table — structured, no parsing.
+            2. JavaScript — on-disk ``.js``, then the ``Report.javascript`` field.
+
+        A Custom Report carries no configuration of its own; its contract is
+        that of the report it references, so discovery follows that link.
 
         Returns:
-            Dictionary with human-readable filter requirements and guidance
+            ``(parsed_filters_or_None, diagnostics)``. ``parsed_filters`` is
+            not None even for a report with zero filters, as long as discovery
+            positively established that — see ``diagnostics["status"]``.
         """
-        requirements = {"common_required_filters": [], "common_optional_filters": [], "guidance": []}
+        diagnostics: Dict[str, Any] = {"status": "unresolved"}
 
-        # Build human-readable descriptions for each filter
-        for filter_def in parsed_filters.get("filters", []):
-            fieldname = filter_def.get("fieldname", "")
-            label = filter_def.get("label", fieldname)
-            fieldtype = filter_def.get("fieldtype", "")
-            options = filter_def.get("options")
-            default = filter_def.get("default")
-            is_required = filter_def.get("required", False)
-
-            # Build description
-            description = f"{fieldname}"
-            if label and label != fieldname:
-                description = f"{fieldname} ({label})"
-
-            # Add type and options info
-            if fieldtype == "Select" and options and isinstance(options, list):
-                options_str = ", ".join(options[:3])  # Show first 3 options
-                if len(options) > 3:
-                    options_str += f", ... ({len(options)} options)"
-                description += f" - Select: {options_str}"
-            elif fieldtype == "Link" and options:
-                description += f" - Link to {options}"
-            elif fieldtype:
-                description += f" - {fieldtype}"
-
-            # Add default value info
-            if default:
-                description += f" (default: {default})"
-
-            # Categorize
-            if is_required:
-                requirements["common_required_filters"].append(description)
-            else:
-                requirements["common_optional_filters"].append(description)
-
-        # Add guidance
-        if requirements["common_required_filters"]:
-            requirements["guidance"].append(
-                f"This report requires {len(requirements['common_required_filters'])} mandatory filters. "
-                "All required filters must be provided for successful execution."
-            )
-
-        if requirements["common_optional_filters"]:
-            requirements["guidance"].append(
-                f"Additionally, {len(requirements['common_optional_filters'])} optional filters are available "
-                "to refine results. These have default values if not specified."
-            )
-
-        return requirements
-
-    def _analyze_filter_requirements(self, report_name: str, report_type: str) -> Dict[str, Any]:
-        """Analyze filter requirements for the report (fallback for pattern-based matching)"""
-        requirements = {"common_required_filters": [], "common_optional_filters": [], "guidance": []}
-
-        # Add specific guidance based on report name patterns
-        report_lower = report_name.lower()
-
-        if "sales_analytics" in report_lower or "sales analytics" in report_lower:
-            requirements["common_required_filters"] = [
-                "doc_type (Sales Invoice, Sales Order, Quotation, etc.)",
-                "tree_type (Customer, Item, Territory, etc.)",
-                "value_quantity (Value or Quantity)",
-            ]
-            requirements["common_optional_filters"] = [
-                "from_date and to_date (defaults to current fiscal year)",
-                "company (uses default company if not specified)",
-            ]
-            requirements["guidance"].append(
-                "For Sales Analytics: Use doc_type='Sales Invoice', tree_type='Customer', and value_quantity='Value' for customer-wise revenue analysis"
-            )
-
-        elif "quotation trends" in report_lower:
-            requirements["common_required_filters"] = ["based_on (Item, Customer, Territory, etc.)"]
-            requirements["common_optional_filters"] = [
-                "from_date and to_date (defaults to current fiscal year)",
-                "company (uses default company if not specified)",
-            ]
-            requirements["guidance"].append(
-                "For Quotation Trends: based_on field is mandatory - use 'Item' for item-wise trends or 'Customer' for customer-wise analysis"
-            )
-
-        elif "profit" in report_lower and "loss" in report_lower:
-            requirements["common_required_filters"] = ["company", "from_date", "to_date"]
-            requirements["guidance"].append(
-                "P&L Statement requires company and date range for financial period analysis"
-            )
-
-        elif "receivable" in report_lower:
-            requirements["common_required_filters"] = ["company"]
-            requirements["common_optional_filters"] = ["customer", "as_on_date"]
-            requirements["guidance"].append(
-                "Accounts Receivable typically needs company filter, optionally filter by specific customer"
-            )
-
-        elif "balance_sheet" in report_lower or "balance sheet" in report_lower:
-            requirements["common_required_filters"] = ["company", "as_on_date"]
-            requirements["guidance"].append(
-                "Balance Sheet requires company and specific date for financial position"
-            )
-
-        # General guidance based on report type
-        if report_type == "Script Report":
-            requirements["guidance"].append(
-                "Script Reports often have mandatory filters - check filter definitions or use filters_definition field for exact requirements"
-            )
-        elif report_type == "Query Report":
-            requirements["guidance"].append(
-                "Query Reports may require company or date filters depending on the underlying query"
-            )
-
-        return requirements
-
-    def _discover_script_report_filters(self, report_name: str, report_doc):
-        """
-        Discover Script Report filters from multiple sources, first non-empty
-        wins, recording a diagnostic for each attempt so a silent empty result
-        is debuggable by agents and users (issue #203).
-
-        Order:
-            1. ``Report.filters`` child table (structured, no parsing).
-            2. JS — on-disk .js file, then the ``Report.javascript`` DB field.
-
-        Returns:
-            (parsed_filters_or_None, discovery_diagnostics dict)
-        """
-        diagnostics = {}
+        js_doc = report_doc
+        reference = getattr(report_doc, "reference_report", None)
+        if getattr(report_doc, "report_type", None) == "Custom Report" and reference:
+            diagnostics["reference_report"] = reference
+            try:
+                js_doc = frappe.get_doc("Report", reference)
+            except Exception as e:
+                diagnostics["reference_report_error"] = f"{type(e).__name__}: {e}"
 
         # --- Source 1: Report.filters child table ---
-        child_rows = report_doc.get("filters") or []
+        child_rows = report_doc.get("filters") or js_doc.get("filters") or []
         diagnostics["filters_child_table"] = {
             "row_count": len(child_rows),
             "status": "success" if child_rows else "empty",
         }
         if child_rows:
             parsed = self._parse_filters_child_table(child_rows)
-            if parsed.get("filters"):
+            if parsed["filters"]:
                 diagnostics["filters_child_table"]["filters_found"] = len(parsed["filters"])
+                diagnostics["status"] = "resolved"
+                diagnostics["requiredness"] = "declared_in_report_filters"
                 return parsed, diagnostics
 
         # --- Source 2: JavaScript (disk file, then DB field) ---
-        self._last_discovery_diagnostics = {}
-        parsed = self._parse_script_report_filters(report_name, report_doc.module)
-        diagnostics["javascript"] = getattr(self, "_last_discovery_diagnostics", {})
-        return parsed, diagnostics
+        js_diag = {"js_file": {}, "js_db_field": {}}
+        diagnostics["javascript"] = js_diag
+        resolution = None
+
+        try:
+            js_path = self._resolve_report_js_path(js_doc.name, js_doc.module)
+            js_diag["js_file"]["path"] = js_path
+            if js_path and os.path.exists(js_path):
+                js_diag["js_file"]["file_exists"] = True
+                js_diag["js_file"]["file_readable"] = os.access(js_path, os.R_OK)
+                # nosemgrep: frappe-security-file-traversal — path built from frappe.get_module_path + scrubbed report metadata, not user input
+                with open(js_path, encoding="utf-8") as f:
+                    js_content = f.read()
+                resolution = resolve_filters(
+                    js_content, report_name=js_doc.name, load_shared=self._load_shared_namespace
+                )
+                self._record_resolution(js_diag["js_file"], resolution)
+            else:
+                js_diag["js_file"]["file_exists"] = False
+
+            if resolution is None or resolution.status == "unresolved":
+                js_db = frappe.db.get_value("Report", js_doc.name, "javascript")
+                js_diag["js_db_field"]["present"] = bool(js_db)
+                if js_db:
+                    db_resolution = resolve_filters(
+                        js_db, report_name=js_doc.name, load_shared=self._load_shared_namespace
+                    )
+                    self._record_resolution(js_diag["js_db_field"], db_resolution)
+                    if db_resolution.status != "unresolved":
+                        resolution = db_resolution
+
+        except Exception as e:
+            js_diag["error"] = f"{type(e).__name__}: {str(e)}"
+            frappe.log_error(f"Error parsing report filters for {report_name}: {str(e)}")
+
+        # --- Source 3: Query Report SQL placeholders ---
+        # A Query Report's ``%(fieldname)s`` placeholders are a *binding*
+        # contract: frappe.db.sql() raises if one is missing. Equally, a
+        # non-empty query with no placeholders positively establishes that the
+        # report takes no filters — an answer, not a failure.
+        if resolution is None or resolution.status == "unresolved":
+            sql_parsed, sql_diag = self._filters_from_query_placeholders(js_doc)
+            if sql_diag:
+                diagnostics["query_placeholders"] = sql_diag
+            if sql_parsed is not None:
+                diagnostics["status"] = sql_diag["status"]
+                diagnostics["requiredness"] = "declared_in_sql_placeholders"
+                return sql_parsed, diagnostics
+
+        if resolution is None or resolution.status == "unresolved":
+            return None, diagnostics
+
+        diagnostics["status"] = resolution.status
+        diagnostics["requiredness"] = "declared_in_js"
+        if resolution.partial:
+            diagnostics["partial"] = True
+
+        return self._categorize_filters(resolution.filters), diagnostics
+
+    def _filters_from_query_placeholders(self, report_doc) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Derive a Query Report's filter contract from its SQL placeholders."""
+        if getattr(report_doc, "report_type", None) != "Query Report":
+            return None, None
+
+        query = (getattr(report_doc, "query", None) or "").strip()
+        if not query:
+            return None, {"status": "empty", "note": "report has no stored query"}
+
+        # Positional %s placeholders carry no names, so no contract can be read.
+        # `%%` is an escaped literal percent (e.g. LIKE '%%foo%%') and must be
+        # removed before the scan, otherwise it masks a real positional marker.
+        # The scan must NOT exclude `%s)` — `IN (%s)` is the commonest shape,
+        # and treating it as "no placeholders" would positively assert that a
+        # parameterised report takes no filters.
+        if re.search(r"%s(?!\w)", query.replace("%%", "")):
+            return None, {
+                "status": "unresolved",
+                "note": "query uses positional %s placeholders; filter names cannot be determined",
+            }
+
+        names = []
+        for name in re.findall(r"%\((\w+)\)s", query):
+            if name not in names:
+                names.append(name)
+
+        if not names:
+            return self._categorize_filters([]), {
+                "status": "no_filters_declared",
+                "note": "query defines no %(name)s placeholders, so the report takes no filters",
+            }
+
+        filters = [
+            {
+                "fieldname": name,
+                "label": name.replace("_", " ").title(),
+                "required": True,
+            }
+            for name in names
+        ]
+        return self._categorize_filters(filters), {
+            "status": "resolved",
+            "placeholders": names,
+            "note": "filters derived from %(name)s placeholders in the report SQL; every placeholder is "
+            "mandatory because the query fails without it. Field types are not declared in SQL.",
+        }
+
+    @staticmethod
+    def _record_resolution(target: Dict[str, Any], resolution) -> None:
+        """Fold a resolver outcome into the diagnostics payload."""
+        target["status"] = resolution.status
+        target["filters_found"] = len(resolution.filters)
+        if resolution.sources:
+            target["resolved_from"] = resolution.sources
+        if resolution.partial:
+            target["partial"] = True
+        if resolution.notes:
+            target["note"] = "; ".join(resolution.notes)
+
+    @staticmethod
+    def _categorize_filters(filters: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Split resolved filters into required / conditional / optional names."""
+        required, optional, conditional = [], [], []
+        for filter_def in filters:
+            name = filter_def["fieldname"]
+            if filter_def.get("required"):
+                required.append(name)
+            elif filter_def.get("mandatory_depends_on"):
+                conditional.append(name)
+            else:
+                optional.append(name)
+        return {
+            "filters": filters,
+            "required_filters": required,
+            "optional_filters": optional,
+            "conditional_filters": conditional,
+        }
 
     def _parse_filters_child_table(self, child_rows) -> Dict[str, Any]:
         """Convert ``Report.filters`` child-table rows to the parsed-filter shape."""
         filters = []
-        required_filters = []
-        optional_filters = []
         for row in child_rows:
             fieldname = row.get("fieldname")
             if not fieldname:
@@ -337,35 +374,27 @@ class ReportRequirements(BaseTool):
                 "fieldtype": row.get("fieldtype"),
                 "options": row.get("options"),
                 "default": row.get("default_value") or row.get("default"),
-                "required": is_required,
             }
             # Drop empty keys for a clean payload.
             filter_def = {k: v for k, v in filter_def.items() if v not in (None, "")}
             filter_def["required"] = is_required
             filters.append(filter_def)
-            (required_filters if is_required else optional_filters).append(fieldname)
 
-        return {
-            "filters": filters,
-            "required_filters": required_filters,
-            "optional_filters": optional_filters,
-        }
+        return self._categorize_filters(filters)
 
-    def _resolve_report_js_path(self, report_name: str, module_name: str):
+    def _resolve_report_js_path(self, report_name: str, module_name: str) -> Optional[str]:
         """
-        Resolve the on-disk path of a Script Report's .js file.
+        Resolve the on-disk path of a report's .js file.
 
         Uses Frappe's own resolution (``get_module_path`` + ``scrub``) rather
         than reconstructing the path by looping over installed apps, so custom
         apps with non-trivial package layouts resolve correctly. Returns None
         for custom (DB-only) modules, which have no disk path (issue #203).
-
-        Returns:
-            Absolute path string, or None if the module has no disk location.
         """
-        import os
-
         from frappe.modules import get_module_path, scrub
+
+        if not module_name:
+            return None
 
         # Custom modules exist only in the DB (no files on disk).
         if frappe.get_cached_value("Module Def", module_name, "custom"):
@@ -375,214 +404,246 @@ class ReportRequirements(BaseTool):
         report_folder = scrub(report_name)
         return os.path.join(module_path, "report", report_folder, f"{report_folder}.js")
 
-    def _extract_filters_from_js(self, js_content: str):
+    # ------------------------------------------------------------------
+    # Shared-namespace resolution (injected into the frappe-free resolver)
+    # ------------------------------------------------------------------
+
+    def _load_shared_namespace(self, namespace: str) -> Optional[str]:
         """
-        Extract the ``filters: [...]`` array from report JS and parse it.
+        Return the JavaScript source that defines *namespace*, or None.
 
-        Returns:
-            (parsed_filters_or_None, diagnostic_note). diagnostic_note explains
-            why nothing was parsed, so callers can surface it.
+        Report JS commonly inherits its filters from a shared object such as
+        ``erpnext.financial_statements``. The namespace does NOT reliably map
+        to a file path (``erpnext.pre_sales`` lives in ``utils/sales_common.js``,
+        ``hrms.leave_utils`` in ``utils/leave_utils.js``), so the definition
+        site is located by a bounded content search rather than by building a
+        path out of the namespace segments.
+
+        The search is confined to installed apps' ``public/js`` trees, skips
+        vendored/build directories and caps file size. Both hits and misses are
+        cached: a miss costs a full walk of every installed app's public/js
+        (~27ms on a six-app bench, and it grows with the number of apps), and
+        without a negative entry that walk would repeat on every call. Run
+        ``bench clear-cache`` after installing an app that adds a new shared
+        namespace.
         """
-        # Find the start of the filters array. Anchor on "filters:" then the
-        # next "[" — note this does not handle programmatically-built filters
-        # (e.g. ``filters: get_filters()``); that case is reported via the
-        # diagnostic note rather than failing silently.
-        filters_start = js_content.find("filters:")
-        if filters_start == -1:
-            filters_start = js_content.find('"filters"')
-        if filters_start == -1:
-            return None, "no 'filters:' key found in JS"
+        if not namespace or not _NAMESPACE_RE.match(namespace):
+            return None
 
-        bracket_start = js_content.find("[", filters_start)
-        if bracket_start == -1:
-            return None, "no '[' after 'filters:' (filters may be built programmatically)"
+        cached_path = frappe.cache().hget("fac_js_namespace_path", namespace)
+        if cached_path == _NAMESPACE_MISS:
+            return None
+        if cached_path and os.path.exists(cached_path):
+            return self._read_js(cached_path)
 
-        # Guard against anchoring far past the key (e.g. filters: fn(); ... [ ).
-        between = js_content[filters_start:bracket_start]
-        if "(" in between or ";" in between:
-            return None, "'filters:' is not a literal array (built programmatically)"
+        needles = (
+            f"{namespace} =",
+            f"{namespace}=",
+            f'frappe.provide("{namespace}")',
+            f"frappe.provide('{namespace}')",
+        )
 
-        # Count brackets to find the matching closing bracket.
-        bracket_count = 0
-        bracket_end = bracket_start
-        for i in range(bracket_start, len(js_content)):
-            if js_content[i] == "[":
-                bracket_count += 1
-            elif js_content[i] == "]":
-                bracket_count -= 1
-                if bracket_count == 0:
-                    bracket_end = i
-                    break
-
-        if bracket_count != 0:
-            return None, "mismatched brackets in filters array"
-
-        filters_text = js_content[bracket_start + 1 : bracket_end]
-        parsed = self._parse_js_filter_array(filters_text)
-        if not parsed or not parsed.get("filters"):
-            return None, "filters array found but no filter objects parsed (unexpected JS syntax)"
-        return parsed, None
-
-    def _parse_script_report_filters(self, report_name: str, module_name: str) -> Dict[str, Any]:
-        """
-        Parse JavaScript filter definitions for a Script Report.
-
-        Tries the on-disk .js file first (path resolved via Frappe), then falls
-        back to the ``Report.javascript`` DB field (covers custom DB-only
-        modules and reports whose JS lives in the doc). Stores a diagnostic of
-        what was attempted on ``frappe.local`` for the caller to surface.
-
-        Returns:
-            Dictionary containing parsed filters, or None if parsing fails.
-        """
-        import os
-
-        diag = {"js_file": {}, "js_db_field": {}}
         try:
-            # --- Source 1: on-disk .js file ---
-            js_path = self._resolve_report_js_path(report_name, module_name)
-            diag["js_file"]["path"] = js_path
-            if js_path and os.path.exists(js_path):
-                diag["js_file"]["file_exists"] = True
-                diag["js_file"]["file_readable"] = os.access(js_path, os.R_OK)
-                # nosemgrep: frappe-security-file-traversal — path built from frappe.get_module_path + scrubbed report metadata, not user input
-                with open(js_path, encoding="utf-8") as f:
-                    js_content = f.read()
-                parsed, note = self._extract_filters_from_js(js_content)
-                diag["js_file"]["status"] = "success" if parsed else "failed"
-                diag["js_file"]["filters_found"] = len(parsed["filters"]) if parsed else 0
-                if note:
-                    diag["js_file"]["note"] = note
-                if parsed:
-                    self._last_discovery_diagnostics = diag
-                    return parsed
-            else:
-                diag["js_file"]["file_exists"] = False
-
-            # --- Source 2: Report.javascript DB field ---
-            js_db = frappe.db.get_value("Report", report_name, "javascript")
-            diag["js_db_field"]["present"] = bool(js_db)
-            if js_db:
-                parsed, note = self._extract_filters_from_js(js_db)
-                diag["js_db_field"]["status"] = "success" if parsed else "failed"
-                diag["js_db_field"]["filters_found"] = len(parsed["filters"]) if parsed else 0
-                if note:
-                    diag["js_db_field"]["note"] = note
-                if parsed:
-                    self._last_discovery_diagnostics = diag
-                    return parsed
-
-            self._last_discovery_diagnostics = diag
+            installed = frappe.get_installed_apps()
+        except Exception:
             return None
 
-        except Exception as e:
-            diag["error"] = f"{type(e).__name__}: {str(e)}"
-            self._last_discovery_diagnostics = diag
-            frappe.log_error(f"Error parsing Script Report filters for {report_name}: {str(e)}")
+        # The namespace root is usually the app name; try it first, then the
+        # remaining apps, so the common case costs one directory walk.
+        root = namespace.split(".", 1)[0]
+        apps = ([root] if root in installed else []) + [a for a in installed if a != root]
+
+        for app in apps:
+            js_root = self._app_js_root(app)
+            if not js_root:
+                continue
+            for path in self._iter_js_files(js_root):
+                content = self._read_js(path)
+                if content and any(needle in content for needle in needles):
+                    frappe.cache().hset("fac_js_namespace_path", namespace, path)
+                    return content
+
+        frappe.cache().hset("fac_js_namespace_path", namespace, _NAMESPACE_MISS)
+        return None
+
+    @staticmethod
+    def _app_js_root(app: str) -> Optional[str]:
+        try:
+            js_root = os.path.realpath(frappe.get_app_path(app, "public", "js"))
+        except Exception:
+            return None
+        return js_root if os.path.isdir(js_root) else None
+
+    @staticmethod
+    def _iter_js_files(js_root: str):
+        """Yield .js files under *js_root*, staying inside it and skipping vendored trees."""
+        for dirpath, dirnames, filenames in os.walk(js_root):
+            dirnames[:] = [d for d in dirnames if d not in _JS_SEARCH_SKIP_DIRS]
+            for filename in filenames:
+                if not filename.endswith(".js") or filename.endswith(".min.js"):
+                    continue
+                path = os.path.join(dirpath, filename)
+                real = os.path.realpath(path)
+                # Containment check: a symlink must not lead outside the tree.
+                if not real.startswith(js_root + os.sep):
+                    continue
+                try:
+                    if os.path.getsize(real) > _JS_SEARCH_MAX_BYTES:
+                        continue
+                except OSError:
+                    continue
+                yield real
+
+    @staticmethod
+    def _read_js(path: str) -> Optional[str]:
+        try:
+            # nosemgrep: frappe-security-file-traversal — path is confined to an installed app's public/js tree by _iter_js_files
+            with open(path, encoding="utf-8") as f:
+                return f.read()
+        except (OSError, UnicodeDecodeError):
             return None
 
-    def _parse_js_filter_array(self, filters_text: str) -> Dict[str, Any]:
+    # ------------------------------------------------------------------
+    # Guidance
+    # ------------------------------------------------------------------
+
+    def _build_requirements_from_parsed_filters(self, parsed: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Parse JavaScript filter array text into Python dictionary.
-
-        Args:
-            filters_text: String containing JavaScript filter objects
-
-        Returns:
-            Dictionary with 'filters', 'required_filters', 'optional_filters'
+        Build human-readable filter requirements from resolved filter definitions.
         """
-        import re
+        requirements: Dict[str, Any] = {
+            "common_required_filters": [],
+            "common_optional_filters": [],
+            "conditional_filters": [],
+            "guidance": [],
+        }
 
-        filters = []
-        required_filters = []
-        optional_filters = []
-
-        # Split into individual filter objects using proper brace counting
-        filter_objects = []
-        brace_count = 0
-        current_obj_start = None
-
-        for i, char in enumerate(filters_text):
-            if char == "{":
-                if brace_count == 0:
-                    current_obj_start = i
-                brace_count += 1
-            elif char == "}":
-                brace_count -= 1
-                if brace_count == 0 and current_obj_start is not None:
-                    # Extract complete object (excluding braces)
-                    obj_content = filters_text[current_obj_start + 1 : i]
-                    filter_objects.append(obj_content)
-                    current_obj_start = None
-
-        for filter_obj in filter_objects:
-            filter_def = {}
-
-            # Keys may be bare (fieldname:) or quoted (JSON-style "fieldname":),
-            # and may use template literals (`x`). Tolerate optional surrounding
-            # quotes on the key so JSON-style report JS isn't silently skipped
-            # (issue #203).
-            # Extract fieldname
-            fieldname_match = re.search(r'["\']?fieldname["\']?\s*:\s*["\']([^"\']+)["\']', filter_obj)
-            if fieldname_match:
-                filter_def["fieldname"] = fieldname_match.group(1)
+        for filter_def in parsed["filters"]:
+            description = self._describe_filter(filter_def)
+            if filter_def.get("required"):
+                requirements["common_required_filters"].append(description)
+            elif filter_def.get("mandatory_depends_on"):
+                requirements["conditional_filters"].append(
+                    f"{description} - required when: {filter_def['mandatory_depends_on']}"
+                )
             else:
-                continue  # Skip if no fieldname
+                requirements["common_optional_filters"].append(description)
 
-            # Extract label — supports __("x"), "x", and `x` (template literal),
-            # with bare or quoted key.
-            label_match = re.search(
-                r'["\']?label["\']?\s*:\s*__\(\s*[`"\']([^`"\']+)[`"\']\s*\)'
-                r'|["\']?label["\']?\s*:\s*[`"\']([^`"\']+)[`"\']',
-                filter_obj,
+        if requirements["common_required_filters"]:
+            requirements["guidance"].append(
+                f"This report declares {len(requirements['common_required_filters'])} mandatory filters. "
+                "All of them must be provided for successful execution."
             )
-            if label_match:
-                filter_def["label"] = label_match.group(1) or label_match.group(2)
 
-            # Extract fieldtype
-            fieldtype_match = re.search(r'["\']?fieldtype["\']?\s*:\s*["\']([^"\']+)["\']', filter_obj)
-            if fieldtype_match:
-                filter_def["fieldtype"] = fieldtype_match.group(1)
-
-            # Extract options (can be array or string)
-            options_match = re.search(
-                r'["\']?options["\']?\s*:\s*(\[[\s\S]*?\]|["\'][^"\']+["\'])', filter_obj
+        if requirements["conditional_filters"]:
+            requirements["guidance"].append(
+                "Some filters are mandatory only under a condition (see conditional_filters). "
+                "Evaluate the condition against the values you intend to send."
             )
-            if options_match:
-                options_str = options_match.group(1)
-                if options_str.startswith("["):
-                    # Array format - extract string values
-                    option_values = re.findall(r'["\']([^"\']+)["\']', options_str)
-                    filter_def["options"] = option_values
-                else:
-                    # String format (e.g., Link to DocType)
-                    filter_def["options"] = options_str.strip("\"'")
 
-            # Extract default value
-            default_match = re.search(
-                r'["\']?default["\']?\s*:\s*["\']([^"\']+)["\']|["\']?default["\']?\s*:\s*(\d+)',
-                filter_obj,
+        if requirements["common_optional_filters"]:
+            requirements["guidance"].append(
+                f"{len(requirements['common_optional_filters'])} optional filters are available to refine results."
             )
-            if default_match:
-                filter_def["default"] = default_match.group(1) or default_match.group(2)
 
-            # Extract required flag
-            reqd_match = re.search(r'["\']?reqd["\']?\s*:\s*(1|true)', filter_obj, re.IGNORECASE)
-            filter_def["required"] = bool(reqd_match)
+        if not parsed["filters"]:
+            requirements["guidance"].append("This report declares no filters and can be run without any.")
 
-            filters.append(filter_def)
+        # Filters marked required here are the ones the report's own
+        # configuration declares. Server-side report code may enforce more, so
+        # an empty required list is not a guarantee.
+        requirements["guidance"].append(
+            "Requiredness reflects what the report configuration declares. Server-side report code may "
+            "enforce additional mandatory filters; if execution fails with a 'mandatory' error, supply the "
+            "field named in that error."
+        )
 
-            # Categorize as required or optional
-            if filter_def["required"]:
-                required_filters.append(filter_def["fieldname"])
-            else:
-                optional_filters.append(filter_def["fieldname"])
+        return requirements
+
+    @staticmethod
+    def _describe_filter(filter_def: Dict[str, Any]) -> str:
+        """Render one filter definition as a single readable line."""
+        fieldname = filter_def.get("fieldname", "")
+        label = filter_def.get("label", fieldname)
+        fieldtype = filter_def.get("fieldtype", "")
+        options = filter_def.get("options")
+
+        description = fieldname
+        if label and label != fieldname:
+            description = f"{fieldname} ({label})"
+
+        if fieldtype in ("Select", "Autocomplete") and isinstance(options, list) and options:
+            shown = ", ".join(str(o) for o in options[:5])
+            if len(options) > 5:
+                shown += f", ... ({len(options)} options)"
+            description += f" - {fieldtype}: {shown}"
+        elif fieldtype in ("Link", "MultiSelectList", "Dynamic Link") and options:
+            description += f" - {fieldtype} to {options}"
+        elif fieldtype:
+            description += f" - {fieldtype}"
+
+        if filter_def.get("options_source") == "runtime":
+            description += " (options computed at runtime; query the target DocType for valid values)"
+
+        if filter_def.get("default") is not None:
+            description += f" (default: {filter_def['default']})"
+        elif filter_def.get("default_source") == "runtime":
+            expr = filter_def.get("default_expr")
+            description += f" (default supplied by the UI at runtime{': ' + expr if expr else ''})"
+
+        if filter_def.get("depends_on") and not filter_def.get("mandatory_depends_on"):
+            description += f" (shown when: {filter_def['depends_on']})"
+
+        return description
+
+    @staticmethod
+    def _generic_filter_guidance(report_type: str, diagnostics: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Guidance for reports whose filter contract could not be resolved.
+
+        This deliberately asserts nothing about which filters exist. The
+        previous implementation guessed from the report's name and was wrong
+        for every report it matched on this bench — it claimed Profit and Loss
+        Statement needs ``from_date``/``to_date`` and Balance Sheet needs
+        ``as_on_date``, none of which exist on those reports. A wrong filter
+        list is worse than no list: the caller sends fabricated values, gets an
+        empty result, and reports it as a finding.
+        """
+        guidance = []
+        guidance.append(
+            "Filter definitions could not be determined for this report - see discovery_diagnostics "
+            "for what was attempted and why it failed."
+        )
+        guidance.append(
+            "Do not guess filter names. Run the report with no filters to see what the server "
+            "requires, or inspect the report definition directly."
+        )
+
+        if report_type == "Query Report":
+            guidance.append(
+                "Query Reports take their filters from the Report's filter configuration or its SQL "
+                "placeholders; the report may accept no filters at all."
+            )
+        elif report_type == "Script Report":
+            guidance.append(
+                "Script Reports define filters in JavaScript, which may build them dynamically in the browser."
+            )
+        elif report_type == "Report Builder":
+            guidance.append(
+                "Report Builder reports store a saved column/filter configuration rather than a filter "
+                "contract; use the underlying DocType's fields to filter instead."
+            )
 
         return {
-            "filters": filters,
-            "required_filters": required_filters,
-            "optional_filters": optional_filters,
+            "common_required_filters": [],
+            "common_optional_filters": [],
+            "conditional_filters": [],
+            "guidance": guidance,
         }
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
 
     def _get_comprehensive_metadata(self, report_name: str) -> Dict[str, Any]:
         """Get comprehensive report metadata - merged from get_report_data functionality"""
@@ -609,6 +670,8 @@ class ReportRequirements(BaseTool):
                     "disabled": getattr(report, "disabled", False),
                     "description": getattr(report, "description", ""),
                     "ref_doctype": getattr(report, "ref_doctype", ""),
+                    # A Custom Report inherits its contract from this report.
+                    "reference_report": getattr(report, "reference_report", ""),
                 },
                 "system_info": {
                     "creation": str(getattr(report, "creation", "")),
@@ -640,25 +703,10 @@ class ReportRequirements(BaseTool):
                     report_config = json.loads(report.json)
                     if "filters" in report_config:
                         metadata["advanced_filters"] = report_config["filters"]
-
-                elif report_type == "Script Report":
-                    # NEW: Parse JavaScript file for filter definitions
-                    module_name = report.module
-                    parsed_filters = self._parse_script_report_filters(report_name, module_name)
-
-                    if parsed_filters:
-                        metadata["advanced_filters"] = parsed_filters
-                    else:
-                        # Fallback: Try Python module (legacy support)
-                        report_module_name = f"{module_name}.report.{report.name.lower().replace(' ', '_')}"
-                        try:
-                            report_module = frappe.get_module(report_module_name)
-                            if hasattr(report_module, "get_filters"):
-                                metadata["advanced_filters"] = report_module.get_filters()
-                            elif hasattr(report_module, "filters"):
-                                metadata["advanced_filters"] = report_module.filters
-                        except Exception:
-                            pass
+                else:
+                    parsed, _diagnostics = self._discover_report_filters(report_name, report)
+                    if parsed:
+                        metadata["advanced_filters"] = parsed
             except Exception as e:
                 frappe.logger().debug(f"Error extracting filters for {report_name}: {str(e)}")
 

--- a/frappe_assistant_core/tests/test_js_filter_resolver.py
+++ b/frappe_assistant_core/tests/test_js_filter_resolver.py
@@ -1,0 +1,792 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/220
+
+``report_requirements`` misreported the filter contract of reports whose
+filters are composed across files — a shared namespace supplies a base array
+through a builder function and the report appends its own with ``.push()``.
+
+These tests exercise the resolver directly. It imports nothing from frappe, so
+this module runs standalone::
+
+    python -m unittest frappe_assistant_core.tests.test_js_filter_resolver
+
+Every snippet below is a minimal reproduction of a shape that exists in shipped
+Frappe/ERPNext report JS. Where a test pins a defect, the docstring names it.
+"""
+
+import unittest
+
+from frappe_assistant_core.plugins.core.tools.js_filter_resolver import (
+    Unresolved,
+    resolve_filters,
+    scan,
+)
+
+# --- Shared namespace, ERPNext ``erpnext.financial_statements`` shape --------
+SHARED_FINANCIAL = """
+frappe.provide("erpnext.financial_statements");
+
+erpnext.financial_statements = {
+	filters: get_filters(),
+	formatter: function (value, row, column, data, default_formatter) {
+		return default_formatter(value, row, column, data);
+	},
+};
+
+function get_filters() {
+	let filters = [
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1,
+		},
+		{
+			fieldname: "filter_based_on",
+			label: __("Filter Based On"),
+			fieldtype: "Select",
+			options: ["Fiscal Year", "Date Range"],
+			default: ["Fiscal Year"],
+			reqd: 1,
+		},
+		{
+			fieldname: "period_start_date",
+			label: __("Start Date"),
+			fieldtype: "Date",
+			depends_on: "eval:doc.filter_based_on == 'Date Range'",
+			mandatory_depends_on: "eval:doc.filter_based_on == 'Date Range'",
+		},
+		{
+			fieldname: "from_fiscal_year",
+			label: __("Start Year"),
+			fieldtype: "Link",
+			options: "Fiscal Year",
+			reqd: 1,
+			depends_on: "eval:doc.filter_based_on == 'Fiscal Year'",
+		},
+		{
+			fieldname: "presentation_currency",
+			label: __("Currency"),
+			fieldtype: "Select",
+			options: erpnext.get_presentation_currency_list(),
+		},
+		{
+			fieldname: "cost_center",
+			label: __("Cost Center"),
+			fieldtype: "MultiSelectList",
+			get_data: function (txt) {
+				return frappe.db.get_link_options("Cost Center", txt);
+			},
+			options: "Cost Center",
+		},
+	];
+
+	let fy_filters = filters.filter((x) => {
+		return ["from_fiscal_year"].includes(x.fieldname);
+	});
+	fy_filters.forEach((x) => {
+		x.default = "2025-2026";
+	});
+
+	return filters;
+}
+"""
+
+# ``$.extend({}, ns)`` then three pushes — profit_and_loss_statement.js shape.
+PNL = """
+frappe.query_reports["Profit and Loss Statement"] = $.extend({}, erpnext.financial_statements);
+
+erpnext.utils.add_dimensions("Profit and Loss Statement", 10);
+
+frappe.query_reports["Profit and Loss Statement"]["filters"].push({
+	fieldname: "selected_view",
+	label: __("Select View"),
+	fieldtype: "Select",
+	options: [
+		{ value: "Report", label: __("Report View") },
+		{ value: "Growth", label: __("Growth View") },
+	],
+	default: "Report",
+	reqd: 1,
+});
+
+frappe.query_reports["Profit and Loss Statement"]["filters"].push({
+	fieldname: "accumulated_values",
+	label: __("Accumulated Values"),
+	fieldtype: "Check",
+	default: 1,
+});
+"""
+
+# ``$.extend(ns, {...})`` — namespace as the FIRST argument — plus a splice.
+CASH_FLOW = """
+frappe.query_reports["Cash Flow"] = $.extend(erpnext.financial_statements, {
+	name_field: "section",
+});
+
+frappe.query_reports["Cash Flow"]["filters"].splice(4, 1);
+
+frappe.query_reports["Cash Flow"]["filters"].push({
+	fieldname: "include_default_book_entries",
+	label: __("Include Default FB Entries"),
+	fieldtype: "Check",
+	default: 1,
+});
+"""
+
+
+def _shared_loader(mapping):
+    return lambda namespace: mapping.get(namespace)
+
+
+FINANCIAL_LOADER = _shared_loader({"erpnext.financial_statements": SHARED_FINANCIAL})
+
+
+class TestScanner(unittest.TestCase):
+    """The lexical layer must know where strings and comments begin and end."""
+
+    def test_comment_bodies_are_blanked(self):
+        sanitized, code, clean = scan('let a = 1; // filters: [{fieldname: "x"}]\nlet b = 2;')
+        self.assertTrue(clean)
+        self.assertNotIn("fieldname", sanitized)
+        self.assertNotIn("fieldname", code)
+
+    def test_string_contents_blanked_in_sanitized_but_kept_in_code(self):
+        sanitized, code, clean = scan('let a = "has } brace and // slashes";')
+        self.assertTrue(clean)
+        self.assertNotIn("}", sanitized)
+        self.assertIn("}", code)
+
+    def test_offsets_are_preserved(self):
+        source = 'a = "xx"; /* yy */ b = 1;'
+        sanitized, code, _clean = scan(source)
+        self.assertEqual(len(sanitized), len(source))
+        self.assertEqual(len(code), len(source))
+
+    def test_url_inside_string_is_not_a_comment(self):
+        sanitized, _code, clean = scan('let u = "https://example.com/x"; let v = 1;')
+        self.assertTrue(clean)
+        self.assertIn("let v = 1;", sanitized)
+
+    def test_unterminated_string_is_reported(self):
+        _sanitized, _code, clean = scan('let a = "never closed;')
+        self.assertFalse(clean)
+
+
+class TestNoFabrication(unittest.TestCase):
+    """The highest-severity class: asserting filters that do not exist.
+
+    A wrong filter list is worse than an empty one — the caller sends a
+    fabricated value, gets an empty result set, and reports it as a finding.
+    """
+
+    def test_fully_commented_out_config_yields_no_filters(self):
+        """Regression: the old regex parser read `my_filter` out of a file whose
+        entire contents are commented out, and reported it as required."""
+        js = """
+// frappe.query_reports["Calculated Discount Mismatch"] = {
+// 	filters: [
+// 		{
+// 			"fieldname": "my_filter",
+// 			"label": __("My Filter"),
+// 			"fieldtype": "Data",
+// 			"reqd": 1,
+// 		},
+// 	],
+// };
+"""
+        result = resolve_filters(js, report_name="Calculated Discount Mismatch")
+        self.assertEqual(result.filters, [])
+        self.assertEqual(result.status, "no_filters_declared")
+
+    def test_block_commented_config_yields_no_filters(self):
+        js = '/* frappe.query_reports["X"] = { filters: [{fieldname: "ghost", reqd: 1}] }; */'
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.filters, [])
+
+    def test_report_name_in_a_comment_does_not_create_filters(self):
+        js = """
+// See also frappe.query_reports["Other Report"]
+frappe.query_reports["X"] = { filters: [{ fieldname: "real", fieldtype: "Data" }] };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["real"])
+
+    def test_option_values_are_never_raw_js_fragments(self):
+        """Every option must be a clean value — never `, { value: ` or `__(`."""
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        for filter_def in result.filters:
+            options = filter_def.get("options")
+            if not isinstance(options, list):
+                continue
+            for option in options:
+                if not isinstance(option, str):
+                    continue
+                for fragment in ("{", "}", "__(", "value:", "label:"):
+                    self.assertNotIn(fragment, option, f"{filter_def['fieldname']} option {option!r}")
+
+
+class TestEmptyIsAnAnswer(unittest.TestCase):
+    """ "No filters declared" must be distinguishable from "could not parse"."""
+
+    def test_explicit_empty_array(self):
+        result = resolve_filters('frappe.query_reports["X"] = { filters: [] };', report_name="X")
+        self.assertEqual(result.status, "no_filters_declared")
+        self.assertEqual(result.filters, [])
+
+    def test_empty_config_object(self):
+        result = resolve_filters('frappe.query_reports["X"] = {};', report_name="X")
+        self.assertEqual(result.status, "no_filters_declared")
+
+    def test_config_without_filters_key(self):
+        js = 'frappe.query_reports["X"] = { onload: function (r) { r.x = 1; } };'
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.status, "no_filters_declared")
+
+    def test_genuinely_unparseable_stays_unresolved(self):
+        js = 'frappe.query_reports["X"] = { filters: buildThem() };'
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.status, "unresolved")
+        self.assertTrue(any("buildThem" in n for n in result.notes))
+
+
+class TestLiteralArrays(unittest.TestCase):
+    """Shapes covered by issue #203 must keep working."""
+
+    def test_bare_keys(self):
+        js = """
+frappe.query_reports["X"] = { filters: [
+    { fieldname: "company", label: __("Company"), fieldtype: "Link", options: "Company", reqd: 1 },
+    { fieldname: "bom", label: __("BOM"), fieldtype: "Link", options: "BOM" }
+] };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "bom"])
+        self.assertTrue(result.filters[0]["required"])
+        self.assertFalse(result.filters[1]["required"])
+
+    def test_json_style_quoted_keys(self):
+        js = """
+frappe.query_reports["X"] = { "filters": [
+    { "fieldname": "company", "label": __("Company"), "fieldtype": "Link", "reqd": 1 }
+] };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+        self.assertTrue(result.filters[0]["required"])
+
+    def test_template_literal_label(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", label: `Company` }] };'
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.filters[0]["label"], "Company")
+
+    def test_apostrophe_in_translated_label_survives(self):
+        """`__("Payable Account's Party")` used to kill the label match."""
+        js = """frappe.query_reports["X"] = { filters: [
+    { fieldname: "c", label: __("Show Net Values in Party Account's Report") }
+] };"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.filters[0]["label"], "Show Net Values in Party Account's Report")
+
+    def test_layout_breaks_are_not_filters(self):
+        js = """frappe.query_reports["X"] = { filters: [
+    { fieldtype: "Break" },
+    { fieldname: "c", fieldtype: "Data" }
+] };"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["c"])
+
+    def test_mandatory_is_an_alias_for_reqd(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", mandatory: 1 }] };'
+        result = resolve_filters(js, report_name="X")
+        self.assertTrue(result.filters[0]["required"])
+
+    def test_first_filters_key_is_not_blindly_taken(self):
+        """A nested `filters:` inside get_query must not win over the real one."""
+        js = """
+function get_filters() {
+	let filters = [
+		{
+			fieldname: "customer",
+			fieldtype: "Link",
+			get_query: function () {
+				return { filters: [["Customer", "disabled", "=", 0]] };
+			},
+		},
+		{ fieldname: "company", fieldtype: "Link", reqd: 1 },
+	];
+	return filters;
+}
+frappe.query_reports["X"] = { filters: get_filters() };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["customer", "company"])
+
+
+class TestOptionForms(unittest.TestCase):
+    """Every option shape found in shipped report JS."""
+
+    def _options(self, options_js, fieldtype="Select"):
+        js = (
+            f'frappe.query_reports["X"] = {{ filters: [{{ fieldname: "f", '
+            f'fieldtype: "{fieldtype}", options: {options_js} }}] }};'
+        )
+        return resolve_filters(js, report_name="X").filters[0]
+
+    def test_array_of_strings(self):
+        self.assertEqual(self._options('["A", "B"]')["options"], ["A", "B"])
+
+    def test_array_of_value_label_objects_returns_values_only(self):
+        got = self._options('[{ value: "Report", label: __("Report View") }]')
+        self.assertEqual(got["options"], ["Report"])
+
+    def test_numeric_values_survive(self):
+        """`[{value: 1, label: __("Jan")}]` must yield [1], not [] and not labels."""
+        got = self._options('[{ value: 1, label: __("Jan") }, { value: 2, label: __("Feb") }]')
+        self.assertEqual(got["options"], [1, 2])
+
+    def test_leading_blank_choice_is_dropped(self):
+        """`["", {value: "Item"...}]` used to desync quote pairing entirely."""
+        got = self._options(
+            '["", { value: "Item", label: __("Item") }, { value: "Customer", label: __("Customer") }]'
+        )
+        self.assertEqual(got["options"], ["Item", "Customer"])
+
+    def test_newline_joined_select_string_is_split(self):
+        got = self._options('"\\nDraft\\nSubmitted\\nCancelled"')
+        self.assertEqual(got["options"], ["Draft", "Submitted", "Cancelled"])
+
+    def test_link_doctype_string_kept_as_string(self):
+        got = self._options('"Company"', fieldtype="Link")
+        self.assertEqual(got["options"], "Company")
+
+    def test_runtime_call_is_flagged_not_dropped(self):
+        got = self._options("erpnext.get_presentation_currency_list()")
+        self.assertNotIn("options", got)
+        self.assertEqual(got["options_source"], "runtime")
+        self.assertIn("get_presentation_currency_list", got["options_expr"])
+
+    def test_get_data_callback_flags_runtime_options(self):
+        js = """frappe.query_reports["X"] = { filters: [
+    { fieldname: "f", fieldtype: "MultiSelectList", get_data: function (txt) { return []; } }
+] };"""
+        got = resolve_filters(js, report_name="X").filters[0]
+        self.assertEqual(got["options_source"], "runtime")
+
+
+class TestDefaultForms(unittest.TestCase):
+    def _default(self, default_js):
+        js = f'frappe.query_reports["X"] = {{ filters: [{{ fieldname: "f", default: {default_js} }}] }};'
+        return resolve_filters(js, report_name="X").filters[0]
+
+    def test_string_default(self):
+        self.assertEqual(self._default('"Yearly"')["default"], "Yearly")
+
+    def test_numeric_default(self):
+        self.assertEqual(self._default("1")["default"], 1)
+
+    def test_single_element_array_is_unwrapped(self):
+        """`default: ["Fiscal Year"]` on a scalar Select must not stay a list."""
+        self.assertEqual(self._default('["Fiscal Year"]')["default"], "Fiscal Year")
+
+    def test_runtime_expression_is_surfaced_not_dropped(self):
+        got = self._default('frappe.defaults.get_user_default("Company")')
+        self.assertNotIn("default", got)
+        self.assertEqual(got["default_source"], "runtime")
+        self.assertIn("get_user_default", got["default_expr"])
+
+    def test_indexed_array_literal_is_not_mistaken_for_the_default(self):
+        """hrms `employee_birthday.js` writes `default: ["Jan",...,"Dec"][getMonth()]`.
+
+        The array is only the head of the expression; one element is chosen at
+        runtime. Returning the literal would hand the caller a 12-element list
+        as the default of a scalar Select.
+        """
+        got = self._default('["Jan", "Feb", "Mar"][frappe.datetime.get_today().getMonth()]')
+        self.assertNotIn("default", got)
+        self.assertEqual(got["default_source"], "runtime")
+        self.assertIn("getMonth", got["default_expr"])
+
+    def test_literal_followed_by_a_method_call_is_not_taken_verbatim(self):
+        got = self._default('"2025-01-01".slice(0, 4)')
+        self.assertNotIn("default", got)
+        self.assertEqual(got["default_source"], "runtime")
+
+    def test_options_array_followed_by_filter_call_is_unresolved(self):
+        js = (
+            'frappe.query_reports["X"] = { filters: [{ fieldname: "f", fieldtype: "Select", '
+            'options: ["A", "B"].filter((x) => x !== "B") }] };'
+        )
+        got = resolve_filters(js, report_name="X").filters[0]
+        self.assertNotIn("options", got)
+        self.assertEqual(got["options_source"], "runtime")
+
+
+class TestConditionalMetadata(unittest.TestCase):
+    def test_depends_on_with_apostrophes_is_not_truncated(self):
+        """The old regex captured `eval:doc.filter_based_on == ` and stopped."""
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        by_name = {f["fieldname"]: f for f in result.filters}
+        expected = "eval:doc.filter_based_on == 'Date Range'"
+        self.assertEqual(by_name["period_start_date"]["depends_on"], expected)
+        self.assertEqual(by_name["period_start_date"]["mandatory_depends_on"], expected)
+
+    def test_depends_on_does_not_leak_from_mandatory_depends_on(self):
+        js = """frappe.query_reports["X"] = { filters: [
+    { fieldname: "f", mandatory_depends_on: "eval:doc.a == 'b'" }
+] };"""
+        got = resolve_filters(js, report_name="X").filters[0]
+        self.assertNotIn("depends_on", got)
+        self.assertEqual(got["mandatory_depends_on"], "eval:doc.a == 'b'")
+
+
+class TestCrossFileComposition(unittest.TestCase):
+    """The core of issue #220."""
+
+    def test_extend_clone_plus_push_yields_the_full_contract(self):
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        self.assertEqual(result.status, "resolved")
+        names = [f["fieldname"] for f in result.filters]
+        # six inherited from the shared namespace, two appended by the report
+        self.assertEqual(
+            names,
+            [
+                "company",
+                "filter_based_on",
+                "period_start_date",
+                "from_fiscal_year",
+                "presentation_currency",
+                "cost_center",
+                "selected_view",
+                "accumulated_values",
+            ],
+        )
+        self.assertIn("shared:erpnext.financial_statements", result.sources)
+        self.assertIn("builder:get_filters()", result.sources)
+        self.assertIn("push", result.sources)
+
+    def test_namespace_as_first_extend_argument(self):
+        """cash_flow.js uses `$.extend(ns, {...})` with no `{}` clone."""
+        result = resolve_filters(CASH_FLOW, report_name="Cash Flow", load_shared=FINANCIAL_LOADER)
+        self.assertEqual(result.status, "resolved")
+        self.assertIn("company", [f["fieldname"] for f in result.filters])
+        self.assertIn("include_default_book_entries", [f["fieldname"] for f in result.filters])
+
+    def test_splice_is_refused_not_replayed(self):
+        """Index replay against a possibly-incomplete base array would remove
+        the wrong filter silently. Refuse and say so instead."""
+        result = resolve_filters(CASH_FLOW, report_name="Cash Flow", load_shared=FINANCIAL_LOADER)
+        self.assertTrue(result.partial)
+        self.assertTrue(any(".splice()" in n for n in result.notes))
+
+    def test_missing_shared_source_is_diagnosed(self):
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=lambda ns: None)
+        self.assertTrue(any("financial_statements" in n for n in result.notes))
+
+    def test_resolution_does_not_leak_between_reports(self):
+        """`$.extend` is shallow in the browser, so Cash Flow's mutations would
+        corrupt P&L in a live session. Static resolution must deep-copy."""
+        first = resolve_filters(CASH_FLOW, report_name="Cash Flow", load_shared=FINANCIAL_LOADER)
+        second = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        self.assertNotIn("include_default_book_entries", [f["fieldname"] for f in second.filters])
+        self.assertIn("presentation_currency", [f["fieldname"] for f in second.filters])
+        self.assertIn("include_default_book_entries", [f["fieldname"] for f in first.filters])
+
+    def test_push_only_report_with_no_base(self):
+        js = """
+frappe.query_reports["X"] = {};
+frappe.query_reports["X"]["filters"].push({ fieldname: "extra", fieldtype: "Data" });
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["extra"])
+
+
+class TestBuilderFunctions(unittest.TestCase):
+    def test_builder_declared_above_the_assignment(self):
+        """payment_ledger.js declares get_filters() before using it."""
+        js = """
+function get_filters() {
+	let filters = [
+		{ fieldname: "company", fieldtype: "Link", options: "Company", reqd: 1 },
+		{ fieldname: "party", fieldtype: "MultiSelectList", options: "party_type" },
+	];
+	return filters;
+}
+
+frappe.query_reports["Payment Ledger"] = { filters: get_filters() };
+"""
+        result = resolve_filters(js, report_name="Payment Ledger")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "party"])
+
+    def test_builder_returning_an_array_literal_directly(self):
+        js = """
+function gf() { return [{ fieldname: "company", fieldtype: "Link", reqd: 1 }]; }
+frappe.query_reports["X"] = { filters: gf() };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+
+    def test_arrow_function_builder(self):
+        js = """
+const gf = () => {
+	const filters = [{ fieldname: "company", fieldtype: "Link" }];
+	return filters;
+};
+frappe.query_reports["X"] = { filters: gf() };
+"""
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+
+    def test_builder_runtime_default_assignment_is_flagged(self):
+        """get_filters() fills fiscal-year defaults after building the array.
+        Reporting "no default" would send the caller hunting for a value the
+        UI always pre-fills."""
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        by_name = {f["fieldname"]: f for f in result.filters}
+        self.assertEqual(by_name["from_fiscal_year"].get("default_source"), "runtime")
+        self.assertTrue(any("from_fiscal_year" in n for n in result.notes))
+
+    def test_unknown_builder_is_diagnosed(self):
+        js = 'frappe.query_reports["X"] = { filters: notDefinedHere() };'
+        result = resolve_filters(js, report_name="X")
+        self.assertEqual(result.status, "unresolved")
+        self.assertTrue(any("notDefinedHere" in n for n in result.notes))
+
+
+class TestRuntimeInjection(unittest.TestCase):
+    def test_add_dimensions_is_reported_as_partial(self):
+        result = resolve_filters(PNL, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        self.assertTrue(result.partial)
+        self.assertTrue(any("add_dimensions" in n for n in result.notes))
+
+
+class TestUnresolvedMarker(unittest.TestCase):
+    def test_equality_and_normalisation(self):
+        self.assertEqual(Unresolved("a  b"), Unresolved("a b"))
+        self.assertNotEqual(Unresolved("a"), Unresolved("b"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+
+
+class TestMalformedInputTerminates(unittest.TestCase):
+    """Every input must produce an answer in bounded time.
+
+    A stray closing bracket used to make the value reader stop where it
+    started, spinning the enclosing array/object loop forever — an MCP worker
+    wedged on a report file.
+    """
+
+    def _bounded(self, fn, *args):
+        import threading
+
+        box = {}
+        thread = threading.Thread(target=lambda: box.setdefault("r", fn(*args)), daemon=True)
+        thread.start()
+        thread.join(10)
+        self.assertFalse(thread.is_alive(), "resolver did not terminate")
+        return box.get("r")
+
+    def test_stray_closers_do_not_hang(self):
+        for js in (
+            'frappe.query_reports["X"] = { filters: [{ a: 1, ] }] };',
+            'frappe.query_reports["X"] = { filters: [ 1, } ] };',
+            'frappe.query_reports["X"] = { a: ) };',
+            'frappe.query_reports["X"] = { filters: [[[[ };',
+        ):
+            result = self._bounded(resolve_filters, js, "X")
+            self.assertIsNotNone(result)
+            self.assertIn(result.status, ("resolved", "unresolved", "no_filters_declared"))
+
+    def test_regex_containing_a_brace_does_not_unbalance_the_scan(self):
+        js = """
+frappe.query_reports["R"] = {
+	onload: function (r) { r.h(r.h().replace(/}/g, "")); },
+	filters: [{ fieldname: "company", fieldtype: "Link", reqd: 1 }]
+};
+"""
+        result = self._bounded(resolve_filters, js, "R")
+        self.assertEqual(result.status, "resolved")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+
+    def test_regex_containing_slash_star_does_not_open_a_comment(self):
+        """`/^[0-9+\\-/*.() ]+$/` used to swallow the whole config as a comment,
+        after which the resolver confidently answered 'no filters'."""
+        js = """
+function is_numeric(v) { return /^[0-9+\\-/*.() ]+$/.test(v); }
+frappe.query_reports["Silent"] = { filters: [
+	{ fieldname: "company", fieldtype: "Link", reqd: 1 },
+	{ fieldname: "from_date", fieldtype: "Date", reqd: 1 }
+] };
+"""
+        result = self._bounded(resolve_filters, js, "Silent")
+        self.assertEqual(result.status, "resolved")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "from_date"])
+
+    def test_quote_inside_a_regex_does_not_invert_the_views(self):
+        js = """
+function esc(v) { return v.replace(/'/g, ""); }
+frappe.query_reports["G"] = { filters: [
+	{ fieldname: "company", fieldtype: "Link", default: "RIGHT CO" }
+] };
+"""
+        result = self._bounded(resolve_filters, js, "G")
+        self.assertEqual(result.status, "resolved")
+        self.assertEqual(result.filters[0]["default"], "RIGHT CO")
+
+    def test_nested_template_literal_keeps_following_keys(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ label: `a${ `]` }b`, fieldname: "f" }] };'
+        result = self._bounded(resolve_filters, js, "X")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["f"])
+
+
+class TestNeverClaimsNoFiltersWrongly(unittest.TestCase):
+    """`no_filters_declared` is a positive assertion and must be earned."""
+
+    def test_array_of_factory_calls_is_unresolved_not_empty(self):
+        js = (
+            'function cf(){return {fieldname:"company",reqd:1};}\n'
+            'frappe.query_reports["F"] = { filters: [cf(), cf()] };'
+        )
+        result = resolve_filters(js, report_name="F")
+        self.assertEqual(result.status, "unresolved")
+
+    def test_unresolvable_namespace_is_unresolved_not_empty(self):
+        js = 'frappe.query_reports["Stock Analytics"] = $.extend({}, erpnext.stock_analytics);'
+        result = resolve_filters(js, report_name="Other Name", load_shared=lambda ns: None)
+        self.assertEqual(result.status, "unresolved")
+
+    def test_filters_assigned_after_registration(self):
+        js = (
+            'frappe.query_reports["L"] = { onload: function(){} };\n'
+            'frappe.query_reports["L"].filters = [{ fieldname: "company", fieldtype: "Link", reqd: 1 }];'
+        )
+        result = resolve_filters(js, report_name="L")
+        self.assertEqual(result.status, "resolved")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+
+    def test_filters_assigned_via_bracket_notation(self):
+        js = (
+            'frappe.query_reports["L"] = {};\n'
+            'frappe.query_reports["L"]["filters"] = [{ fieldname: "co", fieldtype: "Link" }];'
+        )
+        result = resolve_filters(js, report_name="L")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["co"])
+
+
+class TestMutationAttribution(unittest.TestCase):
+    NS = 'erpnext.ns = { filters: [{fieldname:"company",reqd:1},{fieldname:"fiscal_year"}] };'
+
+    def _loader(self, ns):
+        return self.NS if ns == "erpnext.ns" else None
+
+    def test_push_wrapped_onto_a_continuation_line_is_applied(self):
+        js = (
+            'frappe.query_reports["I"] = { filters: [{ fieldname: "company", fieldtype: "Link" }] };\n'
+            'frappe.query_reports["I"]\n\t.filters.push({ fieldname: "warehouse", reqd: 1 });'
+        )
+        result = resolve_filters(js, report_name="I")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "warehouse"])
+
+    def test_a_report_does_not_steal_a_longer_named_siblings_push(self):
+        js = (
+            'frappe.query_reports["Sales Register"] = { filters: [{ fieldname: "company" }] };\n'
+            'frappe.query_reports["Sales Register Detail"] = { filters: [{ fieldname: "company" }] };\n'
+            'frappe.query_reports["Sales Register Detail"].filters.push({ fieldname: "item_code" });'
+        )
+        self.assertEqual(
+            [f["fieldname"] for f in resolve_filters(js, report_name="Sales Register").filters],
+            ["company"],
+        )
+        self.assertEqual(
+            [f["fieldname"] for f in resolve_filters(js, report_name="Sales Register Detail").filters],
+            ["company", "item_code"],
+        )
+
+    def test_a_comment_cannot_redirect_a_push(self):
+        js = (
+            'frappe.query_reports["Report A"] = { filters: [{ fieldname: "company" }] };\n'
+            'frappe.query_reports["Report B"] = { filters: [{ fieldname: "company" }] };\n'
+            "/* keep in sync with Report A */ "
+            'frappe.query_reports["Report B"].filters.push({ fieldname: "b_only" });'
+        )
+        result = resolve_filters(js, report_name="Report A")
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company"])
+
+    def test_later_extend_argument_wins(self):
+        js = 'frappe.query_reports["P"] = $.extend({ filters: [{ fieldname: "local_only" }] }, erpnext.ns);'
+        result = resolve_filters(js, report_name="P", load_shared=self._loader)
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "fiscal_year"])
+
+    def test_chained_concat_is_not_silently_dropped(self):
+        js = (
+            'function base(){return [{ fieldname: "company" }];}\n'
+            'frappe.query_reports["C"] = { filters: base().concat([{ fieldname: "extra", reqd: 1 }]) };'
+        )
+        result = resolve_filters(js, report_name="C")
+        self.assertEqual(result.status, "unresolved")
+        self.assertTrue(result.failed)
+
+    def test_direct_namespace_assignment_resolves(self):
+        js = 'frappe.query_reports["D"] = erpnext.ns;\n'
+        result = resolve_filters(js, report_name="D", load_shared=self._loader)
+        self.assertEqual([f["fieldname"] for f in result.filters], ["company", "fiscal_year"])
+
+
+class TestEscapesAndNumbers(unittest.TestCase):
+    def test_hex_escape_in_a_label(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", label: "Compan\\x79" }] };'
+        self.assertEqual(resolve_filters(js, report_name="X").filters[0]["label"], "Company")
+
+    def test_surrogate_pair_is_joined_and_encodable(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", label: "\\uD83D\\uDE00" }] };'
+        label = resolve_filters(js, report_name="X").filters[0]["label"]
+        self.assertEqual(label, "\U0001f600")
+        label.encode("utf-8")  # must not raise
+
+    def test_hex_number_default(self):
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", default: 0xE1 }] };'
+        self.assertEqual(resolve_filters(js, report_name="X").filters[0]["default"], 225)
+
+    def test_numeric_separator_is_not_truncated(self):
+        """`1_000` must never come back as 1."""
+        js = 'frappe.query_reports["X"] = { filters: [{ fieldname: "c", default: 1_000 }] };'
+        got = resolve_filters(js, report_name="X").filters[0]
+        self.assertNotEqual(got.get("default"), 1)
+        self.assertEqual(got.get("default_source"), "runtime")
+
+
+class TestBuilderMutationAttribution(unittest.TestCase):
+    def test_only_the_assigned_field_is_flagged(self):
+        js = (
+            "function get_filters(){\n"
+            '\tlet f = [{fieldname:"company"},{fieldname:"from_date"},{fieldname:"to_date"}];\n'
+            '\tlet t = ["to_date"].includes("x");\n'
+            "\tf[2].default = frappe.datetime.get_today();\n"
+            "\tfrappe.msgprint(__(\"Please pick a 'from_date'\"));\n"
+            "\treturn f;\n}\n"
+            'frappe.query_reports["B"] = { filters: get_filters() };'
+        )
+        result = resolve_filters(js, report_name="B")
+        by_name = {f["fieldname"]: f for f in result.filters}
+        self.assertEqual(by_name["to_date"].get("default_source"), "runtime")
+        self.assertIsNone(by_name["from_date"].get("default_source"))

--- a/frappe_assistant_core/tests/test_js_filter_resolver.py
+++ b/frappe_assistant_core/tests/test_js_filter_resolver.py
@@ -510,6 +510,27 @@ class TestCrossFileComposition(unittest.TestCase):
         self.assertIn("presentation_currency", [f["fieldname"] for f in second.filters])
         self.assertIn("include_default_book_entries", [f["fieldname"] for f in first.filters])
 
+    def test_report_name_bound_to_a_constant(self):
+        """ERPNext v16 writes `const PL_REPORT_NAME = "..."` and subscripts
+        query_reports with the constant, so a quoted-string-only match finds
+        nothing and the whole contract is lost."""
+        js = """
+const PL_REPORT_NAME = "Profit and Loss Statement";
+
+frappe.query_reports[PL_REPORT_NAME] = $.extend({}, erpnext.financial_statements);
+
+frappe.query_reports[PL_REPORT_NAME]["filters"].push(
+	{ fieldname: "report_template", label: __("Report Template"), fieldtype: "Link" },
+	{ fieldname: "selected_view", label: __("Select View"), fieldtype: "Select", reqd: 1 }
+);
+"""
+        result = resolve_filters(js, report_name="Profit and Loss Statement", load_shared=FINANCIAL_LOADER)
+        self.assertEqual(result.status, "resolved")
+        names = [f["fieldname"] for f in result.filters]
+        self.assertIn("company", names)  # inherited through the constant subscript
+        self.assertIn("report_template", names)  # multiple objects in one push()
+        self.assertIn("selected_view", names)
+
     def test_push_only_report_with_no_base(self):
         js = """
 frappe.query_reports["X"] = {};

--- a/frappe_assistant_core/tests/test_report_requirements_filters.py
+++ b/frappe_assistant_core/tests/test_report_requirements_filters.py
@@ -15,92 +15,37 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/203
+Site-level tests for report_requirements filter discovery.
 
-report_requirements returned empty filter definitions for custom Script Reports
-whose filters are defined in the .js file, and did so silently. Reproduced two
-real triggers and verified the fixes:
+Issues: #203 (silent empty results for JS-defined filters) and #220 (filters
+composed across files, and discovery gated to Script Reports).
 
-  * JSON-style quoted keys ("fieldname": "x") — the regex only matched bare
-    keys (fieldname:), so every filter object was skipped.
-  * filters built programmatically (filters: get_filters()) — there is no
-    literal array to parse; this now surfaces a diagnostic instead of a silent
-    empty result.
-
-Also adds the Report.filters child table as a discovery source, and a
-discovery_diagnostics payload so empty results are debuggable.
+The JS parsing itself is covered by ``test_js_filter_resolver``, which needs no
+site. What is tested here is the orchestration around it: source precedence,
+diagnostics, Custom Report dereferencing, Query Report SQL placeholders, and
+the guarantee that an unresolved report never gets invented filter names.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import frappe
 
 from frappe_assistant_core.plugins.core.tools.report_requirements import ReportRequirements
 from frappe_assistant_core.tests.base_test import BaseAssistantTest
 
-_BARE_KEYS = """
-frappe.query_reports["X"] = { filters: [
-    { fieldname: "company", label: __("Company"), fieldtype: "Link", options: "Company", reqd: 1 },
-    { fieldname: "bom", label: __("BOM"), fieldtype: "Link", options: "BOM" }
-] };
-"""
 
-_QUOTED_KEYS = """
-frappe.query_reports["X"] = { "filters": [
-    { "fieldname": "company", "label": __("Company"), "fieldtype": "Link", "options": "Company", "reqd": 1 },
-    { "fieldname": "bom", "label": __("BOM"), "fieldtype": "Link", "options": "BOM" }
-] };
-"""
-
-_PROGRAMMATIC = """
-function gf() { return [ { fieldname: "company", fieldtype: "Link", options: "Company", reqd: 1 } ]; }
-frappe.query_reports["X"] = { filters: gf() };
-"""
-
-_TEMPLATE_LITERAL = """
-frappe.query_reports["X"] = { filters: [
-    { fieldname: "company", label: `Company`, fieldtype: "Link", options: "Company", reqd: 1 }
-] };
-"""
-
-
-class TestJsFilterParsing(BaseAssistantTest):
-    """The JS parser must tolerate the legal syntax variants that previously
-    produced a silent empty result."""
-
-    def setUp(self):
-        super().setUp()
-        self.tool = ReportRequirements()
-
-    def test_bare_keys_parse(self):
-        parsed, note = self.tool._extract_filters_from_js(_BARE_KEYS)
-        self.assertIsNone(note)
-        self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company", "bom"])
-        self.assertEqual(parsed["required_filters"], ["company"])
-
-    def test_quoted_keys_parse(self):
-        """Regression: JSON-style quoted keys used to yield 0 filters."""
-        parsed, note = self.tool._extract_filters_from_js(_QUOTED_KEYS)
-        self.assertIsNone(note)
-        self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company", "bom"])
-        self.assertEqual(parsed["required_filters"], ["company"])
-
-    def test_template_literal_label_parses_fieldname(self):
-        parsed, note = self.tool._extract_filters_from_js(_TEMPLATE_LITERAL)
-        self.assertIsNone(note)
-        self.assertEqual(parsed["filters"][0]["fieldname"], "company")
-        self.assertEqual(parsed["filters"][0].get("label"), "Company")
-
-    def test_programmatic_filters_report_a_diagnostic_not_silence(self):
-        """Genuinely unparseable (filters built by a function) must surface a
-        note explaining why, rather than returning a bare None."""
-        parsed, note = self.tool._extract_filters_from_js(_PROGRAMMATIC)
-        self.assertIsNone(parsed)
-        self.assertTrue(note)
-        self.assertIn("programmatically", note)
-
-    def test_missing_filters_key_reports_note(self):
-        parsed, note = self.tool._extract_filters_from_js("frappe.query_reports['X'] = {};")
-        self.assertIsNone(parsed)
-        self.assertIn("no 'filters:' key", note)
+def _report_doc(**kwargs):
+    """A Report-like mock. ``name`` needs explicit assignment on MagicMock."""
+    doc = MagicMock()
+    doc.name = kwargs.pop("name", "Some Report")
+    doc.module = kwargs.pop("module", "Nonexistent Module XYZ")
+    doc.report_type = kwargs.pop("report_type", "Script Report")
+    doc.query = kwargs.pop("query", "")
+    doc.reference_report = kwargs.pop("reference_report", None)
+    doc.get.return_value = kwargs.pop("child_rows", [])
+    for key, value in kwargs.items():
+        setattr(doc, key, value)
+    return doc
 
 
 class TestFiltersChildTableSource(BaseAssistantTest):
@@ -121,13 +66,12 @@ class TestFiltersChildTableSource(BaseAssistantTest):
         self.assertEqual(parsed["optional_filters"], ["bom"])
 
     def test_rows_without_fieldname_skipped(self):
-        rows = [{"label": "No fieldname"}, {"fieldname": "ok"}]
-        parsed = self.tool._parse_filters_child_table(rows)
+        parsed = self.tool._parse_filters_child_table([{"label": "No fieldname"}, {"fieldname": "ok"}])
         self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["ok"])
 
 
 class TestDiscoveryOrchestration(BaseAssistantTest):
-    """_discover_script_report_filters prefers the child table and always
+    """_discover_report_filters prefers structured sources and always
     returns a diagnostics payload."""
 
     def setUp(self):
@@ -135,27 +79,157 @@ class TestDiscoveryOrchestration(BaseAssistantTest):
         self.tool = ReportRequirements()
 
     def test_child_table_wins_and_short_circuits_js(self):
-        report_doc = MagicMock()
-        report_doc.module = "Selling"
-        report_doc.get.return_value = [
-            {"fieldname": "company", "label": "Company", "fieldtype": "Link", "mandatory": 1}
-        ]
-
-        parsed, diagnostics = self.tool._discover_script_report_filters("Some Report", report_doc)
+        doc = _report_doc(
+            module="Selling",
+            child_rows=[{"fieldname": "company", "label": "Company", "fieldtype": "Link", "mandatory": 1}],
+        )
+        parsed, diagnostics = self.tool._discover_report_filters("Some Report", doc)
 
         self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company"])
         self.assertEqual(diagnostics["filters_child_table"]["status"], "success")
+        self.assertEqual(diagnostics["status"], "resolved")
+        self.assertEqual(diagnostics["requiredness"], "declared_in_report_filters")
         # JS path not attempted when the child table satisfied discovery.
         self.assertNotIn("javascript", diagnostics)
 
     def test_empty_child_table_falls_through_to_js_with_diagnostics(self):
-        report_doc = MagicMock()
-        report_doc.module = "Nonexistent Module XYZ"
-        report_doc.get.return_value = []  # empty child table
-
-        parsed, diagnostics = self.tool._discover_script_report_filters("No Such Report", report_doc)
+        doc = _report_doc(name="No Such Report")
+        parsed, diagnostics = self.tool._discover_report_filters("No Such Report", doc)
 
         self.assertIsNone(parsed)
         self.assertEqual(diagnostics["filters_child_table"]["status"], "empty")
+        self.assertEqual(diagnostics["status"], "unresolved")
         # JS discovery was attempted and recorded (even though it found nothing).
         self.assertIn("javascript", diagnostics)
+
+    def test_custom_report_inherits_from_reference_report(self):
+        """A Custom Report carries no config of its own; issue #220 — discovery
+        used to stop there and return nothing."""
+        parent = _report_doc(name="Parent Report", module="Selling")
+        parent.get.return_value = [{"fieldname": "company", "fieldtype": "Link", "mandatory": 1}]
+        child = _report_doc(name="My Custom", report_type="Custom Report", reference_report="Parent Report")
+
+        with patch.object(frappe, "get_doc", return_value=parent):
+            parsed, diagnostics = self.tool._discover_report_filters("My Custom", child)
+
+        self.assertEqual(diagnostics["reference_report"], "Parent Report")
+        self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company"])
+
+
+class TestQueryReportPlaceholders(BaseAssistantTest):
+    """A Query Report's SQL placeholders are a binding filter contract."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def test_named_placeholders_become_required_filters(self):
+        doc = _report_doc(
+            report_type="Query Report",
+            query="select name from `tabSales Order` where company = %(company)s and docstatus = %(status)s",
+        )
+        parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+
+        self.assertEqual(sorted(parsed["required_filters"]), ["company", "status"])
+        self.assertEqual(diagnostics["status"], "resolved")
+        self.assertEqual(diagnostics["requiredness"], "declared_in_sql_placeholders")
+
+    def test_query_without_placeholders_declares_no_filters(self):
+        """This is an answer, not a failure — 12 Query Reports on a stock bench."""
+        doc = _report_doc(report_type="Query Report", query="select name from `tabWork Order`")
+        parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+
+        self.assertEqual(parsed["filters"], [])
+        self.assertEqual(diagnostics["status"], "no_filters_declared")
+
+    def test_positional_placeholders_are_not_guessed(self):
+        doc = _report_doc(report_type="Query Report", query="select name from `tabItem` where item_code = %s")
+        parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+
+        self.assertIsNone(parsed)
+        self.assertIn("positional", diagnostics["query_placeholders"]["note"])
+
+
+class TestNoInventedFilters(BaseAssistantTest):
+    """Guidance for an unresolved report must not assert filter names.
+
+    The previous implementation guessed from the report's name and was wrong
+    for every report it matched: it claimed Profit and Loss Statement requires
+    `from_date`/`to_date` and Balance Sheet requires `as_on_date`, none of
+    which exist on those reports.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def test_generic_guidance_names_no_filters(self):
+        for report_type in ("Script Report", "Query Report", "Custom Report", "Report Builder"):
+            guidance = self.tool._generic_filter_guidance(report_type, {})
+            self.assertEqual(guidance["common_required_filters"], [])
+            self.assertEqual(guidance["common_optional_filters"], [])
+            blob = " ".join(guidance["guidance"])
+            for invented in ("as_on_date", "from_date", "to_date", "tree_type", "value_quantity"):
+                self.assertNotIn(invented, blob)
+
+    def test_name_pattern_guessing_is_gone(self):
+        self.assertFalse(hasattr(self.tool, "_analyze_filter_requirements"))
+
+
+class TestSharedNamespaceLoader(BaseAssistantTest):
+    """The shared-JS lookup must stay inside installed apps' public/js trees."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def test_non_identifier_namespaces_are_rejected(self):
+        for bad in ("../../etc/passwd", "erpnext/../../secret", "", "noDotsHere", "a..b", "a.b/c"):
+            self.assertIsNone(self.tool._load_shared_namespace(bad))
+
+    def test_unknown_namespace_returns_none(self):
+        self.assertIsNone(self.tool._load_shared_namespace("definitely.not.a.real.namespace"))
+
+
+class TestErpnextFinancialStatements(BaseAssistantTest):
+    """End-to-end regression for the report named in issue #220."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+        if "erpnext" not in frappe.get_installed_apps():
+            self.skipTest("erpnext not installed")
+        if not frappe.db.exists("Report", "Profit and Loss Statement"):
+            self.skipTest("Profit and Loss Statement not present")
+
+    def test_profit_and_loss_resolves_the_real_contract(self):
+        result = self.tool.execute({"report_name": "Profit and Loss Statement", "include_columns": False})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["filter_discovery_status"], "resolved")
+
+        names = [f["fieldname"] for f in result["filters_definition"]]
+        # Inherited from erpnext.financial_statements via $.extend + get_filters()
+        for expected in ("company", "filter_based_on", "periodicity", "from_fiscal_year"):
+            self.assertIn(expected, names)
+        # Appended by the report itself via ["filters"].push(...)
+        for expected in ("selected_view", "accumulated_values", "include_default_book_entries"):
+            self.assertIn(expected, names)
+        # Fields the old fallback invented must not appear.
+        self.assertNotIn("from_date", names)
+        self.assertNotIn("to_date", names)
+
+    def test_conditional_date_range_contract_is_preserved(self):
+        result = self.tool.execute({"report_name": "Profit and Loss Statement", "include_columns": False})
+        by_name = {f["fieldname"]: f for f in result["filters_definition"]}
+        self.assertIn("period_start_date", by_name)
+        self.assertEqual(
+            by_name["period_start_date"]["mandatory_depends_on"],
+            "eval:doc.filter_based_on == 'Date Range'",
+        )
+        self.assertIn("period_start_date", result.get("conditional_filter_names", []))
+
+    def test_select_options_are_clean_values(self):
+        result = self.tool.execute({"report_name": "Profit and Loss Statement", "include_columns": False})
+        by_name = {f["fieldname"]: f for f in result["filters_definition"]}
+        self.assertEqual(by_name["selected_view"]["options"], ["Report", "Growth", "Margin"])
+        self.assertEqual(by_name["periodicity"]["options"], ["Monthly", "Quarterly", "Half-Yearly", "Yearly"])


### PR DESCRIPTION
## Summary

Fixes #220 — `report_requirements` misreported the filter contract of reports whose filters are **composed across files**. Profit and Loss Statement returned `company, from_date, to_date`; **none of those three exist on that report**.

Investigating the reported case showed the same root defect reaching much further, so this PR fixes the class rather than the instance.

## Reproduced first

```
"common_required_filters": ["company", "from_date", "to_date"],
"note": "'filters:' is not a literal array (built programmatically)"
```

That diagnostic was right *by accident*. The parser anchored on `find("filters:")`, missed it entirely (the file only contains `["filters"].push`), landed on the `[` of an `options:` array inside a pushed object, and bailed. It never opened the shared file where the filters actually live.

The real contract is 4 hops:

| # | File | Construct |
|---|---|---|
| 1 | `profit_and_loss_statement.js:4` | `$.extend({}, erpnext.financial_statements)` |
| 2 | `public/js/financial_statements.js:4` | `filters: get_filters()` |
| 3 | `financial_statements.js:146` | `let filters = [...]; return filters;` |
| 4 | `profit_and_loss_statement.js:8,21,28` | 3 × `["filters"].push({...})` |

## Measured, before and after

All 204 enabled Script/Query/Custom reports on a v15 bench (frappe, erpnext, hrms + 3 custom apps):

| | Before | After |
|---|---|---|
| Resolved | 162 | **184** |
| Positively "no filters" | 0 — not expressible | **20** |
| **Failed / unresolved** | **42 (20.6%)** | **0** |
| Filter definitions surfaced | — | **1,113** |
| Wall clock, whole corpus | — | 2.2s |

## It was not only the composition case

**Query Reports failed 13/13** and got no `discovery_diagnostics` *key at all* — discovery was gated to `report_type == "Script Report"`, and the diagnostics assignment sat inside the gate. Indistinguishable from "this report has no filters". `Trial Balance (Simple)` had a structured `Report Filter` child row sitting unread.

**A fully commented-out file produced a fabricated required filter.** `calculated_discount_mismatch.js` is 100% comments; the regex parser returned `my_filter, required: true` with `note: None` — reported as a clean success.

**Reports that already "succeeded" were returning corrupted contracts:**

| Defect | Before | After |
|---|---|---|
| `depends_on: "eval:doc.x == 'Date Range'"` | `eval:doc.x == ` (truncated at the apostrophe) | full string |
| `options: ["", {value:"Item"...}]` | `[', { value: ', ', label: __(', …]` | `["Item", "Customer", …]` |
| `options: [{value:1, label:__("Jan")}]` | labels, or `[]` | `[1, 2, …]` |
| `default: ["Fiscal Year"]` | dropped | `"Fiscal Year"` |
| `default: ["Jan"…"Dec"][getMonth()]` | all 12 months as a scalar default | `default_source: "runtime"` |

## Changes

- **New `js_filter_resolver.py`** — frappe-free, stdlib only. A string-, comment- **and regex-aware** scanner replaces the per-key regexes; that single change kills six corruption classes at once. Resolves cross-file `$.extend` mixins (namespace in either argument position), builder functions, and `.push()`. **Refuses** index-based `.splice()` with a diagnostic instead of replaying it against a possibly-incomplete base array, where one upstream parse gap would remove the wrong filter *and* keep one the report rejects. Anything not statically evaluable becomes an explicit `default_source` / `options_source` hint carrying the original expression — never a guess.
- **Discovery runs for every report type**, always emits `discovery_diagnostics` + `filter_discovery_status`, and dereferences a Custom Report's `reference_report`.
- **Query Report SQL placeholders** as an authoritative source. `%(name)s` is *binding* — `frappe.db.sql` raises without it — and a non-empty query with none positively establishes "no filters".
- **`no_filters_declared` vs `unresolved`.** The former is a positive assertion and is only made when nothing failed along the way.
- **Deleted the report-name pattern guesser** rather than correcting one branch. Every branch it matched on this bench was wrong (Balance Sheet → `as_on_date`, which does not exist). A fabricated filter list is worse than an honest absence: the caller sends invented values, gets an empty result, and narrates it as a finding.

## Adversarial review

I ran a multi-agent review over the implementation and fixed everything it confirmed. Notable catches, each now pinned by a test:

- **Infinite hang.** A stray closing bracket made the value reader stop where it started, spinning the enclosing loop forever — a wedged MCP worker. Reproduced on `{ a: 1, ] }` and, more realistically, on `.replace(/}/g, "")` in an `onload`.
- **Regex blindness.** `/^[0-9+\-/*.() ]+$/` opened a phantom block comment that swallowed the whole config, after which the resolver answered "no filters" with full confidence. `scan()` now recognises regex literals.
- **`no_filters_declared` claimed wrongly** for an array of factory calls, an unresolvable namespace mixin, and `frappe.query_reports["X"].filters = [...]` assigned after registration.
- **Push mis-attribution** — `"Sales Register"` stole a push belonging to `"Sales Register Detail"` (substring match), and a push wrapped onto a continuation line by prettier was dropped.
- **`base().concat([...])`** silently returned only the builder's array.

Verified independently across 306 report `.js` files bench-wide: **0 hangs, 0 exceptions**.

## Deliberately out of scope

`report_tools._apply_filter_defaults` is a stale fork of the pre-#203 parser, so `generate_report` and `report_requirements` can disagree about the same report's defaults. I implemented the de-duplication, measured it, and **reverted it**: delegating to the resolver applies defaults the old parser missed, and on Cash Flow that means `filter_based_on: "Fiscal Year"` gets set while its dependent `from_fiscal_year`/`to_fiscal_year` are runtime-only — turning a working 17-row call into `Start Year and End Year are mandatory`. Measured delta was 103 added / 0 changed / 0 removed across 204 reports, so it is purely additive, but it changes report *output* and belongs in its own PR with its own testing. Filing separately.

## Also in this PR: an unrelated CI blocker

`frappe/semgrep-rules` added a blocking `frappe-enqueue-without-after-commit` rule upstream. The Linters workflow clones that repo fresh on every run, so **`develop` went red without any change to this app** — I confirmed the identical failure on `develop` before touching anything.

It is a real race, not a false positive. `Assistant Core Settings.on_update` enqueued the job that enables the MCP API while its own transaction was still open; the job calls `server.enable()`, which re-reads the Single via `frappe.get_single` and returns *"MCP API is disabled in settings"* if it observes the pre-save value. Fixed with `enqueue_after_commit=True` rather than a suppression.

Folded in here at the maintainer's request so this PR can go green; it unblocks every other PR too.

## Verification

- 267 app tests pass (`bench run-tests --app frappe_assistant_core`)
- **70 resolver tests run in 0.02s with no site, no DB, no frappe import** — CI stays fast. Each pins a shape found in shipped Frappe/ERPNext report JS, plus anti-fabrication and termination-guarantee assertions.
- Corpus sweep: 204 reports, 0 unresolved, 1,113 filters, 2.2s
- `pre-commit run --all-files` clean — the exact command CI runs — including Frappe semgrep and commitlint

### Checklist

- [x] Conventional commit (`fix:`)
- [x] Targets `develop`
- [x] Passes linters (pre-commit: ruff + Frappe semgrep)
- [x] Tests pass
- [x] No DocType changes (no migration needed)
