### PR TITLE
fix: run filter discovery for every report type (#223)

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/report_requirements.py
+++ b/frappe_assistant_core/plugins/core/tools/report_requirements.py
@@ -19,6 +19,7 @@ Report Requirements Tool for Core Plugin.
 Understand report requirements, structure, and metadata before execution.
 """
 
+import re
 from typing import Any, Dict
 
 import frappe
@@ -42,7 +43,7 @@ class ReportRequirements(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "report_requirements"
-        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. NOTE: Report Builder reports are not supported as they are simple DocType list views without business logic."
+        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. Check 'filter_discovery_status': 'no_filters_declared' means the report genuinely takes no filters, while 'unresolved' means discovery failed and 'discovery_diagnostics' explains why. NOTE: Report Builder reports store a saved column/filter configuration rather than a filter contract and are not yet fully supported."
         self.requires_permission = None  # Permission checked dynamically per report
 
         self.inputSchema = {
@@ -131,26 +132,36 @@ class ReportRequirements(BaseTool):
                     report_name, column_result.get("report_type")
                 )
 
-                # For Script Reports, discover filters from multiple sources and
-                # add to main response.
-                if column_result.get("report_type") == "Script Report":
-                    parsed_filters, diagnostics = self._discover_script_report_filters(
-                        report_name, report_doc
+                # Discovery runs for every report type. Gating it to Script
+                # Reports left Query and Custom Reports with no filter
+                # definitions AND no discovery_diagnostics key, which is
+                # indistinguishable from a report that genuinely takes none
+                # (issue #223).
+                parsed_filters, diagnostics = self._discover_report_filters(report_name, report_doc)
+                result["discovery_diagnostics"] = diagnostics
+                result["filter_discovery_status"] = diagnostics.get("status", "unresolved")
+
+                if parsed_filters and parsed_filters.get("filters"):
+                    result["filters_definition"] = parsed_filters["filters"]
+                    result["required_filter_names"] = parsed_filters.get("required_filters", [])
+                    result["conditional_required_filter_names"] = parsed_filters.get(
+                        "conditional_required_filters", []
                     )
-                    result["discovery_diagnostics"] = diagnostics
+                    result["optional_filter_names"] = parsed_filters.get("optional_filters", [])
 
-                    if parsed_filters and parsed_filters.get("filters"):
-                        result["filters_definition"] = parsed_filters["filters"]
-                        result["required_filter_names"] = parsed_filters.get("required_filters", [])
-                        result["conditional_required_filter_names"] = parsed_filters.get(
-                            "conditional_required_filters", []
-                        )
-                        result["optional_filter_names"] = parsed_filters.get("optional_filters", [])
-
-                        # Override filter_requirements with parsed data instead of pattern-based guesses
-                        result["filter_requirements"] = self._build_requirements_from_parsed_filters(
-                            parsed_filters
-                        )
+                    # Override filter_requirements with parsed data instead of pattern-based guesses
+                    result["filter_requirements"] = self._build_requirements_from_parsed_filters(
+                        parsed_filters
+                    )
+                elif diagnostics.get("status") == "no_filters_declared":
+                    result["filters_definition"] = []
+                    result["required_filter_names"] = []
+                    result["optional_filter_names"] = []
+                    result["filter_requirements"] = {
+                        "common_required_filters": [],
+                        "common_optional_filters": [],
+                        "guidance": ["This report declares no filters and can be run without any."],
+                    }
 
             # Add comprehensive metadata if requested
             if include_metadata:
@@ -344,23 +355,38 @@ class ReportRequirements(BaseTool):
 
         return requirements
 
-    def _discover_script_report_filters(self, report_name: str, report_doc):
+    def _discover_report_filters(self, report_name: str, report_doc):
         """
-        Discover Script Report filters from multiple sources, first non-empty
-        wins, recording a diagnostic for each attempt so a silent empty result
-        is debuggable by agents and users (issue #203).
+        Discover a report's filter contract, recording a diagnostic for every
+        source attempted so an empty result is never silent (issues #203, #223).
 
-        Order:
+        Runs for every report type, not just Script Reports.
+
+        Order (first source that yields an answer wins):
             1. ``Report.filters`` child table (structured, no parsing).
             2. JS — on-disk .js file, then the ``Report.javascript`` DB field.
+            3. ``Report.query`` ``%(name)s`` placeholders, for Query Reports.
+
+        A Custom Report carries no configuration of its own; its contract is
+        that of the report named in ``reference_report``, so discovery follows
+        that link before looking anything up.
 
         Returns:
             (parsed_filters_or_None, discovery_diagnostics dict)
         """
-        diagnostics = {}
+        diagnostics = {"status": "unresolved"}
+
+        source_doc = report_doc
+        reference = getattr(report_doc, "reference_report", None)
+        if getattr(report_doc, "report_type", None) == "Custom Report" and reference:
+            diagnostics["reference_report"] = reference
+            try:
+                source_doc = frappe.get_doc("Report", reference)
+            except Exception as e:
+                diagnostics["reference_report_error"] = f"{type(e).__name__}: {e}"
 
         # --- Source 1: Report.filters child table ---
-        child_rows = report_doc.get("filters") or []
+        child_rows = report_doc.get("filters") or source_doc.get("filters") or []
         diagnostics["filters_child_table"] = {
             "row_count": len(child_rows),
             "status": "success" if child_rows else "empty",
@@ -369,13 +395,87 @@ class ReportRequirements(BaseTool):
             parsed = self._parse_filters_child_table(child_rows)
             if parsed.get("filters"):
                 diagnostics["filters_child_table"]["filters_found"] = len(parsed["filters"])
+                diagnostics["status"] = "resolved"
                 return parsed, diagnostics
 
         # --- Source 2: JavaScript (disk file, then DB field) ---
         self._last_discovery_diagnostics = {}
-        parsed = self._parse_script_report_filters(report_name, report_doc.module)
+        parsed = self._parse_script_report_filters(source_doc.name, source_doc.module)
         diagnostics["javascript"] = getattr(self, "_last_discovery_diagnostics", {})
+        if parsed and parsed.get("filters"):
+            diagnostics["status"] = "resolved"
+            return parsed, diagnostics
+
+        # --- Source 3: Query Report SQL placeholders ---
+        sql_parsed, sql_diagnostics = self._filters_from_query_placeholders(source_doc)
+        if sql_diagnostics:
+            diagnostics["query_placeholders"] = sql_diagnostics
+        if sql_parsed is not None:
+            diagnostics["status"] = sql_diagnostics["status"]
+            return (sql_parsed if sql_parsed.get("filters") else None), diagnostics
+
         return parsed, diagnostics
+
+    def _filters_from_query_placeholders(self, report_doc):
+        """
+        Derive a Query Report's filter contract from its SQL placeholders.
+
+        ``frappe.db.sql(query, filters)`` raises when a named placeholder has no
+        value, so every ``%(name)s`` in ``Report.query`` is mandatory by
+        construction — a stronger statement than anything declared in JS.
+
+        The negative case is just as useful: a non-empty query with no
+        placeholders positively establishes that the report takes no filters.
+        That is an answer, not a discovery failure.
+
+        Returns:
+            (parsed_filters_or_None, diagnostics_or_None)
+        """
+        if getattr(report_doc, "report_type", None) != "Query Report":
+            return None, None
+
+        query = (getattr(report_doc, "query", None) or "").strip()
+        if not query:
+            return None, {"status": "empty", "note": "report has no stored query"}
+
+        # ``%%`` is an escaped literal percent (LIKE '%%foo%%',
+        # date_format(t, '%%H:%%i:%%s')) and must be removed before scanning,
+        # or it masks a real positional marker.
+        if re.search(r"%s(?!\w)", query.replace("%%", "")):
+            return None, {
+                "status": "unresolved",
+                "note": "query uses positional %s placeholders; filter names cannot be determined",
+            }
+
+        names = list(dict.fromkeys(re.findall(r"%\((\w+)\)s", query)))
+
+        if not names:
+            return {
+                "filters": [],
+                "required_filters": [],
+                "conditional_required_filters": [],
+                "optional_filters": [],
+            }, {
+                "status": "no_filters_declared",
+                "note": "query defines no %(name)s placeholders, so the report takes no filters",
+            }
+
+        filters = [
+            {"fieldname": name, "label": name.replace("_", " ").title(), "required": True} for name in names
+        ]
+        return {
+            "filters": filters,
+            "required_filters": names,
+            "conditional_required_filters": [],
+            "optional_filters": [],
+        }, {
+            "status": "resolved",
+            "placeholders": names,
+            "note": (
+                "filters derived from %(name)s placeholders in the report SQL; every placeholder is "
+                "mandatory because the query fails without it. Field types are not declared in SQL."
+            ),
+        }
 
     def _parse_filters_child_table(self, child_rows) -> Dict[str, Any]:
         """Convert ``Report.filters`` child-table rows to the parsed-filter shape."""

--- a/frappe_assistant_core/tests/test_report_requirements_filters.py
+++ b/frappe_assistant_core/tests/test_report_requirements_filters.py
@@ -30,7 +30,7 @@ Also adds the Report.filters child table as a discovery source, and a
 discovery_diagnostics payload so empty results are debuggable.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import frappe
 
@@ -127,7 +127,7 @@ class TestFiltersChildTableSource(BaseAssistantTest):
 
 
 class TestDiscoveryOrchestration(BaseAssistantTest):
-    """_discover_script_report_filters prefers the child table and always
+    """_discover_report_filters prefers the child table and always
     returns a diagnostics payload."""
 
     def setUp(self):
@@ -141,7 +141,7 @@ class TestDiscoveryOrchestration(BaseAssistantTest):
             {"fieldname": "company", "label": "Company", "fieldtype": "Link", "mandatory": 1}
         ]
 
-        parsed, diagnostics = self.tool._discover_script_report_filters("Some Report", report_doc)
+        parsed, diagnostics = self.tool._discover_report_filters("Some Report", report_doc)
 
         self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company"])
         self.assertEqual(diagnostics["filters_child_table"]["status"], "success")
@@ -153,7 +153,7 @@ class TestDiscoveryOrchestration(BaseAssistantTest):
         report_doc.module = "Nonexistent Module XYZ"
         report_doc.get.return_value = []  # empty child table
 
-        parsed, diagnostics = self.tool._discover_script_report_filters("No Such Report", report_doc)
+        parsed, diagnostics = self.tool._discover_report_filters("No Such Report", report_doc)
 
         self.assertIsNone(parsed)
         self.assertEqual(diagnostics["filters_child_table"]["status"], "empty")
@@ -201,3 +201,141 @@ class TestERPNextSharedFilters(BaseAssistantTest):
         definitions = {item["fieldname"]: item for item in parsed["filters"]}
         self.assertEqual(definitions["filter_based_on"]["options"], ["Fiscal Year", "Date Range"])
         self.assertIn("Date Range", definitions["period_start_date"]["mandatory_depends_on"])
+
+
+def _report_doc(**kwargs):
+    """A Report-like mock. ``name`` needs explicit assignment on MagicMock."""
+    doc = MagicMock()
+    doc.name = kwargs.pop("name", "Some Report")
+    doc.module = kwargs.pop("module", "Nonexistent Module XYZ")
+    doc.report_type = kwargs.pop("report_type", "Script Report")
+    doc.query = kwargs.pop("query", "")
+    doc.reference_report = kwargs.pop("reference_report", None)
+    doc.get.return_value = kwargs.pop("child_rows", [])
+    for key, value in kwargs.items():
+        setattr(doc, key, value)
+    return doc
+
+
+def _patched_get_doc(overrides):
+    """Patch frappe.get_doc for specific (doctype, name) pairs only.
+
+    A blanket patch also intercepts frappe.get_cached_value, which routes
+    through get_cached_doc -> get_doc, so unrelated framework lookups would
+    blow up and mask what the test is actually asserting.
+    """
+    real_get_doc = frappe.get_doc
+
+    def fake(*args, **kwargs):
+        key = tuple(args[:2]) if len(args) >= 2 and all(isinstance(a, str) for a in args[:2]) else None
+        result = overrides.get(key) if key else None
+        if isinstance(result, Exception):
+            raise result
+        if result is not None:
+            return result
+        return real_get_doc(*args, **kwargs)
+
+    return patch.object(frappe, "get_doc", side_effect=fake)
+
+
+class TestDiscoveryRunsForEveryReportType(BaseAssistantTest):
+    """Issue #223: discovery used to be gated to Script Reports, so every other
+    type returned no filters AND no diagnostics — indistinguishable from a
+    report that genuinely takes none."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def test_diagnostics_always_carry_a_status(self):
+        for report_type in ("Script Report", "Query Report", "Custom Report", "Report Builder"):
+            _parsed, diagnostics = self.tool._discover_report_filters(
+                "X", _report_doc(report_type=report_type)
+            )
+            self.assertIn("status", diagnostics, report_type)
+            self.assertIn(
+                diagnostics["status"], ("resolved", "no_filters_declared", "unresolved"), report_type
+            )
+
+    def test_custom_report_inherits_from_reference_report(self):
+        """A Custom Report has no configuration of its own; its contract is the
+        report named in reference_report."""
+        parent = _report_doc(name="Parent Report", module="Selling")
+        parent.get.return_value = [{"fieldname": "company", "fieldtype": "Link", "mandatory": 1}]
+        child = _report_doc(
+            name="My Custom",
+            report_type="Custom Report",
+            reference_report="Parent Report",
+            module="Selling",
+        )
+
+        with _patched_get_doc({("Report", "Parent Report"): parent}):
+            parsed, diagnostics = self.tool._discover_report_filters("My Custom", child)
+
+        self.assertEqual(diagnostics["reference_report"], "Parent Report")
+        self.assertEqual([f["fieldname"] for f in parsed["filters"]], ["company"])
+
+    def test_missing_reference_report_is_diagnosed_not_raised(self):
+        child = _report_doc(report_type="Custom Report", reference_report="Gone", module="Selling")
+        with _patched_get_doc({("Report", "Gone"): Exception("not found")}):
+            _parsed, diagnostics = self.tool._discover_report_filters("My Custom", child)
+        self.assertIn("reference_report_error", diagnostics)
+        self.assertIn("status", diagnostics)
+
+
+class TestQueryReportPlaceholders(BaseAssistantTest):
+    """A Query Report's SQL placeholders are a binding filter contract:
+    frappe.db.sql() raises when a named placeholder has no value."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def test_named_placeholders_become_required_filters(self):
+        doc = _report_doc(
+            report_type="Query Report",
+            query="select name from `tabSales Order` where company = %(company)s and docstatus = %(status)s",
+        )
+        parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+
+        self.assertEqual(parsed["required_filters"], ["company", "status"])
+        self.assertEqual(diagnostics["status"], "resolved")
+
+    def test_placeholders_are_deduplicated_in_order(self):
+        doc = _report_doc(
+            report_type="Query Report",
+            query="select a from t where c = %(company)s or d = %(company)s or e = %(year)s",
+        )
+        parsed, _diagnostics = self.tool._discover_report_filters("Q", doc)
+        self.assertEqual(parsed["required_filters"], ["company", "year"])
+
+    def test_query_without_placeholders_declares_no_filters(self):
+        """A positive answer, not a failure — 12 Query Reports on a stock bench."""
+        doc = _report_doc(report_type="Query Report", query="select name from `tabWork Order`")
+        _parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+        self.assertEqual(diagnostics["status"], "no_filters_declared")
+
+    def test_positional_placeholders_are_not_guessed(self):
+        for query in (
+            "select name from `tabItem` where item_code = %s",
+            "select name from `tabItem` where item_group in (%s)",
+            "select name, ifnull(item_name, %s) from `tabItem`",
+        ):
+            doc = _report_doc(report_type="Query Report", query=query)
+            _parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+            self.assertEqual(diagnostics["status"], "unresolved", query)
+            self.assertIn("positional", diagnostics["query_placeholders"]["note"])
+
+    def test_escaped_percent_is_not_a_positional_placeholder(self):
+        """LIKE '%%foo%%' and date_format(t,'%%H:%%i:%%s') are literal percents."""
+        doc = _report_doc(
+            report_type="Query Report",
+            query="select date_format(creation, '%%H:%%i:%%s') from `tabItem` where name like '%%sales%%'",
+        )
+        _parsed, diagnostics = self.tool._discover_report_filters("Q", doc)
+        self.assertEqual(diagnostics["status"], "no_filters_declared")
+
+    def test_script_reports_do_not_use_the_sql_source(self):
+        doc = _report_doc(report_type="Script Report", query="select %(company)s from t")
+        _parsed, diagnostics = self.tool._discover_report_filters("S", doc)
+        self.assertNotIn("query_placeholders", diagnostics)


### PR DESCRIPTION
## Summary

Fixes #223 — `report_requirements` only attempted filter discovery for **Script Reports**. Every other report type fell through to name-pattern guidance with **no `discovery_diagnostics` key at all**, which a caller cannot distinguish from a report that genuinely takes no filters.

This is the other half of the "will this hold for *all* report types?" question raised while reviewing #220. #221 fixed how filters are parsed once discovery runs; this makes discovery run.

Builds directly on #221's parser — no parsing logic is changed.

## Measured

v15 bench, frappe + erpnext + hrms, all 204 enabled Script/Query/Custom reports:

| | after #221 | this PR |
|---|---|---|
| **Query Reports answered** (of 13) | **0** | **13** |
| Reports carrying `discovery_diagnostics` | Script only | **all** |
| Script Reports resolved | 183 | 183 (unchanged) |
| Filter definitions surfaced | 1,113 | 1,113 (unchanged) |
| Whole-corpus runtime | — | 1.4s |

Final state: **184 resolved, 12 `no_filters_declared`, 8 `unresolved`** — see the scope note below for the 8.

## Changes

**Discovery runs for every report type.** The `discovery_diagnostics` assignment sat *inside* `if report_type == "Script Report"`, so the payload added in #203 — whose whole purpose was making empty results debuggable — was unreachable for the types that most needed it. It is now always emitted, including on success.

**Custom Reports dereference `reference_report`.** A Custom Report holds no configuration of its own; its contract is the report it references. Discovery previously stopped at the child document and found nothing. A missing or unreadable parent is recorded as `reference_report_error` rather than raised.

**Query Reports derive their contract from `Report.query`.** `frappe.db.sql(query, filters)` raises when a named placeholder has no value, so every `%(name)s` is mandatory *by construction* — a stronger statement than anything declared in JS. Verified against this bench:

```
Trial Balance (Simple)     placeholders=['company']   child row: company, Link, mandatory=1   ← agree exactly
Completed Work Orders      placeholders=[]            → takes no filters
Sales Partners Commission  placeholders=[]            → takes no filters
```

The negative case is what does the heavy lifting: a non-empty query with **no** placeholders positively establishes the report takes no filters, resolving 12 of the 13. Positional `%s` stays `unresolved` rather than guessed, and `%%` escapes are stripped first so `LIKE '%%foo%%'` and `date_format(t, '%%H:%%i:%%s')` are not mistaken for one.

**`filter_discovery_status`** distinguishes `no_filters_declared` from `unresolved`. Conflating them is the #203 signature.

## Deliberately out of scope

The same distinction for Script Reports whose JS declares `filters: []`. #221's extractor reports an empty array and a malformed one with the same note (`"filters array found but no filter objects parsed"`), so telling them apart means changing the parser that PR just added. **Eight reports on this bench are affected** and remain `unresolved`: `ToDo`, `Audit System Hooks`, `Project wise Stock Tracking`, `Available Stock for Packing Items`, `Calculated Discount Mismatch`, `Database Storage Usage By Tables`, `Pending SO Items For Purchase Request`, `Transaction Log Report`. Worth a follow-up; not worth destabilising a freshly merged parser.

Report Builder stays unsupported, but the tool description no longer claims it is "simple DocType list views without business logic" — `Report.json` plus `ref_doctype` meta is a real, server-side contract.

## A caveat worth stating

The Custom Report path is covered by unit tests, **not by a live report**: this bench has zero Custom Reports, so that branch has never executed against a real document. The tests mock `frappe.get_doc` surgically (a blanket patch also intercepts `get_cached_value`, which routes through `get_cached_doc` → `get_doc`, and masks what is being asserted). Someone with a Custom Report in the wild should sanity-check it.

## Verification

- 20 tests in `test_report_requirements_filters` (11 from #221, unchanged and passing, + 9 new)
- Full suite: 202 tests pass
- Corpus sweep: 204 reports, 0 exceptions, 1.4s, filter count unchanged at 1,113
- `pre-commit run --all-files` clean — the exact command CI runs — including Frappe semgrep against the latest upstream rules

### Checklist

- [x] Conventional commit (`fix:`)
- [x] Targets `develop`
- [x] Passes linters
- [x] Tests pass
- [x] No DocType changes (no migration needed)
