### PR TITLE
fix: default list_documents to submitted docs on submittable DocTypes

### DIFF
--- a/docs/skills/list_documents.md
+++ b/docs/skills/list_documents.md
@@ -16,6 +16,23 @@ The `list_documents` tool searches and lists Frappe documents with filtering, fi
 
 **Note:** There is no `page` parameter. Use `limit` to control result size.
 
+## Submitted-Only Default
+
+For **submittable** DocTypes (Sales Invoice, Purchase Invoice, Sales Order, Payment Entry, Stock Entry, and so on) the tool applies `docstatus: 1` automatically when you do not set `docstatus` yourself. Cancelled and draft documents keep their monetary field values, so including them silently inflates any total you compute from the result set.
+
+The applied default is echoed in `filters_applied` and called out in `message`.
+
+To opt out, pass `docstatus` explicitly:
+
+| Goal | Filter |
+|------|--------|
+| Submitted only (default) | — |
+| Cancelled only | `{"docstatus": 2}` |
+| Drafts and submitted | `{"docstatus": [0, 1]}` |
+| Everything | `{"docstatus": [0, 1, 2]}` |
+
+Non-submittable DocTypes (Customer, Item, Supplier, User, ToDo, …) have no `docstatus` semantics and are unaffected.
+
 ## Response Format
 
 ```json
@@ -93,10 +110,19 @@ Key response fields:
 ```json
 {
   "doctype": "Sales Invoice",
-  "filters": {"docstatus": 1},
   "fields": ["name", "customer", "grand_total", "posting_date"],
   "order_by": "posting_date desc",
   "limit": 10
+}
+```
+`docstatus: 1` is the default here — no need to pass it.
+
+### Include cancelled documents (audit / reconciliation)
+```json
+{
+  "doctype": "Sales Invoice",
+  "filters": {"docstatus": [0, 1, 2]},
+  "fields": ["name", "customer", "grand_total", "docstatus", "status"]
 }
 ```
 

--- a/frappe_assistant_core/plugins/core/tools/list_documents.py
+++ b/frappe_assistant_core/plugins/core/tools/list_documents.py
@@ -26,6 +26,108 @@ from frappe import _
 
 from frappe_assistant_core.core.base_tool import BaseTool
 
+# Operators Frappe accepts as the first element of a list-style filter value.
+# Anything else in that position means the list is a set of values, not [op, value].
+FILTER_OPERATORS = {
+    "=",
+    "!=",
+    ">",
+    "<",
+    ">=",
+    "<=",
+    "like",
+    "not like",
+    "in",
+    "not in",
+    "is",
+    "between",
+    "descendants of",
+    "not descendants of",
+    "ancestors of",
+    "not ancestors of",
+}
+
+
+def is_submittable(doctype: str) -> bool:
+    """Whether the DocType carries docstatus semantics (draft/submitted/cancelled)."""
+    try:
+        return bool(frappe.get_meta(doctype).is_submittable)
+    except Exception:
+        # Missing or virtual DocTypes are treated as non-submittable — the caller's
+        # filters are then passed through untouched and Frappe reports the real error.
+        return False
+
+
+def filters_reference_docstatus(filters: Any) -> bool:
+    """True when the caller already constrained docstatus, in any supported filter form."""
+    if isinstance(filters, dict):
+        return "docstatus" in filters
+
+    if isinstance(filters, (list, tuple)):
+        # A single unwrapped condition, e.g. ["docstatus", "=", 1]
+        if filters and isinstance(filters[0], str):
+            return "docstatus" in filters
+
+        for condition in filters:
+            if not isinstance(condition, (list, tuple)) or not condition:
+                continue
+            # ["doctype", "fieldname", op, value] or ["fieldname", op, value]
+            fieldname = condition[1] if len(condition) >= 4 else condition[0]
+            if fieldname == "docstatus":
+                return True
+
+    return False
+
+
+def normalize_docstatus_filter(filters: Any) -> Any:
+    """Accept a bare list of docstatus values, e.g. [0, 1], as an `in` filter.
+
+    Frappe reads a list filter value as [operator, value], so an explicit
+    {"docstatus": [0, 1]} would otherwise be parsed as the operator "0".
+    """
+    if not isinstance(filters, dict):
+        return filters
+
+    value = filters.get("docstatus")
+    if not isinstance(value, (list, tuple)) or not value:
+        return filters
+
+    first = value[0]
+    if isinstance(first, str) and first.lower() in FILTER_OPERATORS:
+        return filters
+
+    normalized = dict(filters)
+    normalized["docstatus"] = ["in", list(value)]
+    return normalized
+
+
+def apply_default_docstatus(doctype: str, filters: Any) -> tuple:
+    """Default submittable DocTypes to submitted documents only.
+
+    Without this, cancelled (docstatus=2) and draft (docstatus=0) documents are
+    returned alongside submitted ones with their monetary fields intact, and any
+    consumer aggregating the result set gets a silently wrong total.
+
+    Returns (filters, applied) where `applied` says whether the default was added.
+    """
+    if not is_submittable(doctype):
+        return filters, False
+
+    if filters_reference_docstatus(filters):
+        return normalize_docstatus_filter(filters), False
+
+    if isinstance(filters, dict):
+        defaulted = dict(filters)
+        defaulted["docstatus"] = 1
+        return defaulted, True
+
+    if isinstance(filters, (list, tuple)):
+        # An unwrapped condition such as ["status", "=", "Paid"] has to be nested first.
+        conditions = [list(filters)] if filters and isinstance(filters[0], str) else list(filters)
+        return conditions + [["docstatus", "=", 1]], True
+
+    return {"docstatus": 1}, True
+
 
 class DocumentList(BaseTool):
     """
@@ -41,7 +143,7 @@ class DocumentList(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "list_documents"
-        self.description = "Search and list Frappe documents with optional filtering. Use this when users want to find records, get lists of documents, or search for data. This is the primary tool for data exploration and discovery."
+        self.description = "Search and list Frappe documents with optional filtering. Use this when users want to find records, get lists of documents, or search for data. This is the primary tool for data exploration and discovery. For submittable DocTypes (invoices, orders, entries) only submitted documents are returned unless you pass docstatus explicitly."
         self.requires_permission = None  # Permission checked dynamically per DocType
 
         self.inputSchema = {
@@ -54,7 +156,7 @@ class DocumentList(BaseTool):
                 "filters": {
                     "type": "object",
                     "default": {},
-                    "description": "Search filters as key-value pairs. Examples: {'status': 'Active'}, {'customer_type': 'Company'}, {'creation': ['>', '2024-01-01']}. Use empty {} to get all records.",
+                    "description": "Search filters as key-value pairs. Examples: {'status': 'Active'}, {'customer_type': 'Company'}, {'creation': ['>', '2024-01-01']}. Use empty {} to get all records. For submittable DocTypes, docstatus=1 (submitted) is applied automatically unless you set docstatus yourself — pass {'docstatus': 2} for cancelled, {'docstatus': [0, 1]} for drafts and submitted.",
                 },
                 "fields": {
                     "type": "array",
@@ -113,6 +215,10 @@ class DocumentList(BaseTool):
                 filters = {}
             filters["name"] = current_user
 
+        # Submittable DocTypes default to submitted documents only, so cancelled and
+        # draft records never reach a consumer that is summing monetary fields.
+        filters, docstatus_defaulted = apply_default_docstatus(doctype, filters)
+
         try:
             # Filter sensitive fields from requested fields for Assistant Users
             from frappe_assistant_core.core.security_config import ADMIN_ONLY_FIELDS, SENSITIVE_FIELDS
@@ -169,6 +275,13 @@ class DocumentList(BaseTool):
                 )
             total_count = count_result[0].get("count") if count_result else 0
 
+            message = f"Found {len(filtered_documents)} {doctype} records"
+            if docstatus_defaulted:
+                message += (
+                    " (submitted only — docstatus=1 applied by default; "
+                    "pass docstatus explicitly to include drafts or cancelled documents)"
+                )
+
             result = {
                 "success": True,
                 "doctype": doctype,
@@ -177,7 +290,7 @@ class DocumentList(BaseTool):
                 "total_count": total_count,
                 "has_more": total_count > limit,
                 "filters_applied": filters,
-                "message": f"Found {len(filtered_documents)} {doctype} records",
+                "message": message,
             }
 
             # Log successful access

--- a/frappe_assistant_core/tests/test_document_tools.py
+++ b/frappe_assistant_core/tests/test_document_tools.py
@@ -147,6 +147,14 @@ class TestDocumentTools(BaseAssistantTest):
                     MagicMock(user="restricted@example.com"),
                 )
             )
+            # Employee is not submittable; stubbed so meta loading does not issue
+            # queries of its own against the mocked frappe.get_list / frappe.get_all.
+            stack.enter_context(
+                patch(
+                    "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+                    return_value=MagicMock(is_submittable=0),
+                )
+            )
             get_all = stack.enter_context(
                 patch(
                     "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_all",
@@ -216,6 +224,12 @@ class TestDocumentTools(BaseAssistantTest):
                 patch(
                     "frappe_assistant_core.plugins.core.tools.list_documents.frappe.session",
                     MagicMock(user="restricted@example.com"),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+                    return_value=MagicMock(is_submittable=0),
                 )
             )
             get_list = stack.enter_context(

--- a/frappe_assistant_core/tests/test_list_documents_docstatus.py
+++ b/frappe_assistant_core/tests/test_list_documents_docstatus.py
@@ -1,0 +1,246 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/227
+
+list_documents applied no docstatus filter unless one was passed explicitly, so
+cancelled (docstatus=2) and draft (docstatus=0) documents were returned alongside
+submitted ones with their monetary fields intact. Anything aggregating the result
+set produced a silently wrong total.
+
+Submittable DocTypes now default to docstatus=1. An explicit docstatus — including
+a bare list of values — is still honoured exactly as passed, and non-submittable
+DocTypes are untouched.
+"""
+
+from contextlib import ExitStack, contextmanager
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from frappe_assistant_core.plugins.core.tools.list_documents import (
+    DocumentList,
+    apply_default_docstatus,
+    filters_reference_docstatus,
+    is_submittable,
+    normalize_docstatus_filter,
+)
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+
+@contextmanager
+def list_documents_harness(submittable=True, rows=None):
+    """Run DocumentList.execute() against mocked permissions and queries.
+
+    Yields the patched frappe.get_list so the caller can assert on the filters
+    that actually reached the database layer.
+    """
+    rows = [{"name": "REC-0001", "grand_total": 100}] if rows is None else rows
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.core.security_config.validate_document_access",
+                return_value={"success": True, "role": "Default"},
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.core.security_config.filter_sensitive_fields",
+                side_effect=lambda doc, _doctype, _role: doc,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.session",
+                MagicMock(user="analyst@example.com"),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+                return_value=MagicMock(is_submittable=1 if submittable else 0),
+            )
+        )
+        get_list = stack.enter_context(
+            patch("frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_list")
+        )
+        get_list.side_effect = [rows, [{"count": len(rows)}]]
+
+        yield get_list
+
+
+def data_call_filters(get_list):
+    """Filters passed to the data query."""
+    return get_list.call_args_list[0].kwargs["filters"]
+
+
+def count_call_filters(get_list):
+    """Filters passed to the pagination count query."""
+    return get_list.call_args_list[1].kwargs["filters"]
+
+
+class TestDocstatusHelpers(BaseAssistantTest):
+    """The filter-inspection helpers must recognise every form Frappe accepts."""
+
+    def test_dict_filter_docstatus_detected(self):
+        self.assertTrue(filters_reference_docstatus({"docstatus": 2}))
+        self.assertFalse(filters_reference_docstatus({"status": "Paid"}))
+
+    def test_list_filter_docstatus_detected(self):
+        self.assertTrue(filters_reference_docstatus([["docstatus", "=", 1]]))
+        self.assertTrue(filters_reference_docstatus([["Sales Invoice", "docstatus", "=", 1]]))
+        self.assertFalse(filters_reference_docstatus([["status", "=", "Paid"]]))
+
+    def test_unwrapped_list_condition_detected(self):
+        """A single condition passed without an enclosing list is still a condition."""
+        self.assertTrue(filters_reference_docstatus(["docstatus", "=", 1]))
+        self.assertFalse(filters_reference_docstatus(["status", "=", "Paid"]))
+
+    def test_empty_filters_reference_nothing(self):
+        self.assertFalse(filters_reference_docstatus({}))
+        self.assertFalse(filters_reference_docstatus([]))
+        self.assertFalse(filters_reference_docstatus(None))
+
+    def test_bare_value_list_normalized_to_in_operator(self):
+        """Frappe reads [0, 1] as [operator, value], so it has to become an `in`."""
+        self.assertEqual(
+            normalize_docstatus_filter({"docstatus": [0, 1]}),
+            {"docstatus": ["in", [0, 1]]},
+        )
+
+    def test_operator_list_left_alone(self):
+        for value in (["in", [0, 1]], ["!=", 2], [">=", 1]):
+            self.assertEqual(normalize_docstatus_filter({"docstatus": value}), {"docstatus": value})
+
+    def test_scalar_docstatus_left_alone(self):
+        self.assertEqual(normalize_docstatus_filter({"docstatus": 2}), {"docstatus": 2})
+
+    def test_caller_filters_are_not_mutated(self):
+        original = {"status": "Paid"}
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=MagicMock(is_submittable=1),
+        ):
+            defaulted, applied = apply_default_docstatus("Sales Invoice", original)
+
+        self.assertTrue(applied)
+        self.assertEqual(defaulted, {"status": "Paid", "docstatus": 1})
+        self.assertEqual(original, {"status": "Paid"}, "caller's dict must not be mutated")
+
+    def test_list_filters_gain_a_docstatus_condition(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=MagicMock(is_submittable=1),
+        ):
+            defaulted, applied = apply_default_docstatus("Sales Invoice", [["status", "=", "Paid"]])
+
+        self.assertTrue(applied)
+        self.assertEqual(defaulted, [["status", "=", "Paid"], ["docstatus", "=", 1]])
+
+    def test_unknown_doctype_is_not_submittable(self):
+        """A meta lookup failure must not break the query path."""
+        self.assertFalse(is_submittable("No Such DocType 227"))
+
+    def test_real_doctype_submittability(self):
+        """Sanity-check the helper against live metadata rather than a mock."""
+        self.assertFalse(is_submittable("ToDo"))
+        if not frappe.db.exists("DocType", "Sales Invoice"):
+            self.skipTest("ERPNext not installed")
+        self.assertTrue(is_submittable("Sales Invoice"))
+
+
+class TestListDocumentsDocstatusDefault(BaseAssistantTest):
+    """End-to-end behaviour of list_documents for submittable DocTypes."""
+
+    def test_unfiltered_query_returns_submitted_only(self):
+        """Regression: cancelled and draft documents used to be returned by default."""
+        with list_documents_harness(submittable=True) as get_list:
+            result = DocumentList().execute(
+                {"doctype": "Purchase Invoice", "fields": ["name", "outstanding_amount"]}
+            )
+
+        self.assertTrue(result.get("success"), result)
+        self.assertEqual(data_call_filters(get_list), {"docstatus": 1})
+
+    def test_applied_default_is_visible_in_filters_applied(self):
+        with list_documents_harness(submittable=True) as get_list:
+            result = DocumentList().execute({"doctype": "Purchase Invoice"})
+
+        self.assertEqual(result["filters_applied"].get("docstatus"), 1)
+        self.assertIn("docstatus=1 applied by default", result["message"])
+
+    def test_count_query_uses_the_same_filters(self):
+        """A count that disagrees with the data query is its own reporting bug."""
+        with list_documents_harness(submittable=True) as get_list:
+            DocumentList().execute({"doctype": "Purchase Invoice"})
+
+        self.assertEqual(count_call_filters(get_list), {"docstatus": 1})
+        self.assertEqual(data_call_filters(get_list), count_call_filters(get_list))
+
+    def test_explicit_cancelled_is_honoured(self):
+        with list_documents_harness(submittable=True) as get_list:
+            result = DocumentList().execute({"doctype": "Purchase Invoice", "filters": {"docstatus": 2}})
+
+        self.assertEqual(data_call_filters(get_list), {"docstatus": 2})
+        self.assertEqual(result["filters_applied"], {"docstatus": 2})
+        self.assertNotIn("applied by default", result["message"])
+
+    def test_explicit_draft_and_submitted_list_is_honoured(self):
+        with list_documents_harness(submittable=True) as get_list:
+            result = DocumentList().execute({"doctype": "Purchase Invoice", "filters": {"docstatus": [0, 1]}})
+
+        self.assertEqual(data_call_filters(get_list), {"docstatus": ["in", [0, 1]]})
+        self.assertEqual(result["filters_applied"], {"docstatus": ["in", [0, 1]]})
+
+    def test_explicit_docstatus_alongside_other_filters(self):
+        with list_documents_harness(submittable=True) as get_list:
+            DocumentList().execute(
+                {
+                    "doctype": "Purchase Invoice",
+                    "filters": {"supplier": "SUP-0001", "docstatus": 0},
+                }
+            )
+
+        self.assertEqual(data_call_filters(get_list), {"supplier": "SUP-0001", "docstatus": 0})
+
+    def test_other_filters_are_preserved_when_defaulting(self):
+        with list_documents_harness(submittable=True) as get_list:
+            DocumentList().execute({"doctype": "Purchase Invoice", "filters": {"status": "Unpaid"}})
+
+        self.assertEqual(data_call_filters(get_list), {"status": "Unpaid", "docstatus": 1})
+
+    def test_list_style_filters_get_the_default(self):
+        with list_documents_harness(submittable=True) as get_list:
+            DocumentList().execute({"doctype": "Purchase Invoice", "filters": [["status", "=", "Unpaid"]]})
+
+        self.assertEqual(data_call_filters(get_list), [["status", "=", "Unpaid"], ["docstatus", "=", 1]])
+
+    def test_non_submittable_doctype_is_untouched(self):
+        with list_documents_harness(submittable=False) as get_list:
+            result = DocumentList().execute(
+                {"doctype": "Customer", "filters": {"customer_group": "Commercial"}}
+            )
+
+        self.assertEqual(data_call_filters(get_list), {"customer_group": "Commercial"})
+        self.assertNotIn("applied by default", result["message"])
+
+    def test_non_submittable_doctype_without_filters_is_untouched(self):
+        with list_documents_harness(submittable=False) as get_list:
+            DocumentList().execute({"doctype": "Customer"})
+
+        self.assertEqual(data_call_filters(get_list), {})


### PR DESCRIPTION
Fixes #227

## Problem

`list_documents` applied no `docstatus` filter unless one was passed explicitly. For submittable DocTypes that meant cancelled (`docstatus=2`) and draft (`docstatus=0`) documents came back alongside submitted ones with their monetary fields intact — so anything summing the result set got a silently wrong total from a well-formed `success: true` response.

## Change

`apply_default_docstatus()` runs before the query is built:

- **Submittable DocTypes default to `docstatus = 1`.** Determined from live metadata (`frappe.get_meta(...).is_submittable`), so custom submittable DocTypes are covered too.
- **Explicit `docstatus` wins**, in every filter form — dict (`{"docstatus": 2}`), list-of-conditions (`[["docstatus", "=", 1]]`), doctype-qualified (`[["Sales Invoice", "docstatus", "=", 1]]`), and unwrapped (`["docstatus", "=", 1]`).
- **A bare value list is normalised.** `{"docstatus": [0, 1]}` becomes `{"docstatus": ["in", [0, 1]]}` — Frappe reads a list filter value as `[operator, value]`, so the raw form would be parsed as the operator `"0"`. `["in", [0, 1]]`, `["!=", 2]` and friends pass through untouched.
- **Non-submittable DocTypes are untouched** — no meta match, no filter added.
- The caller's filter dict is copied, never mutated.

The applied default is visible in the existing `filters_applied` key and called out in `message`. The pagination count query uses the same filters as the data query, so `total_count` can't disagree with `data`.

Tool description and the `filters` schema description now state the default, as does `docs/skills/list_documents.md`.

## Verification

Live instance, Purchase Invoice with 6 submitted + 4 draft records:

| Call | `total_count` | docstatuses returned |
|------|---------------|----------------------|
| no filters | 6 | `[1]` |
| `{"docstatus": [0, 1]}` | 10 | `[0, 1]` |
| `{"docstatus": 0}` | 4 | `[0]` |

Matches the raw `GROUP BY docstatus` counts exactly.

21 new regression tests in `test_list_documents_docstatus.py` cover each acceptance criterion plus the filter-form and normalisation edge cases. Full suite: 223 passed, 0 failed. `pre-commit run` clean.

Two existing #189 tests now stub `frappe.get_meta` — they patch `frappe.get_list`/`get_all` globally, and meta loading would otherwise consume entries from their mocked query stack. `is_submittable=0` there preserves their original intent (Employee is not submittable).

## Acceptance criteria

- [x] Unfiltered `list_documents` on a submittable DocType returns only `docstatus = 1` records
- [x] `filters_applied` in the response reflects the auto-applied `docstatus`
- [x] Explicitly passing `docstatus: 2` returns cancelled records
- [x] Explicitly passing `docstatus: [0, 1]` returns drafts and submitted
- [x] Non-submittable DocTypes behave exactly as before
- [x] Regression test covering each case above

## Note for reviewers

This is a **behaviour change** for existing callers: an unfiltered query against a submittable DocType now returns fewer rows than before. That is the point of the fix, but anything downstream that relied on getting drafts back without asking will need `docstatus` passed explicitly.
