### PR TITLE
fix: surface unresolved Link filter values on zero-row list_documents results

### DIFF
--- a/docs/skills/list_documents.md
+++ b/docs/skills/list_documents.md
@@ -56,6 +56,37 @@ Key response fields:
 - `count` — number of records returned in this response
 - `total_count` — total matching records in the database
 - `has_more` — boolean indicating more records exist beyond the limit
+- `unresolved_filters` — **present only on zero-row results** when a Link filter value matched no record (see below)
+
+## Zero Results: Check `unresolved_filters` First
+
+`count: 0` has two very different causes, and reporting the wrong one to the user is a factual error:
+
+1. **The filter value is valid, there are genuinely no matching records.** "This customer has no open orders."
+2. **The filter value matched no record at all.** The correct answer is "no customer by that name exists" — *not* "this customer has no orders."
+
+When a query returns zero rows and a Link filter value resolves to nothing, the response adds `unresolved_filters`:
+
+```json
+{
+  "success": true,
+  "count": 0,
+  "unresolved_filters": {
+    "customer": {
+      "value": "Grant Plastic",
+      "matched": false,
+      "target_doctype": "Customer",
+      "suggestions": ["Grant Plastics Ltd."]
+    }
+  }
+}
+```
+
+`suggestions` are ranked record names, ready to use directly in a retry. **Never report "no records found" when `unresolved_filters` is present** — either retry with a suggestion or ask the user which they meant.
+
+The key is absent when every filter value resolves, so its absence confirms cause 1. It is only computed for zero-row results, and only for Link fields compared by equality — `like`, `in` and `!=` already say you don't know the exact value.
+
+`success` stays `true` and `count` stays `0`: an unresolved filter is metadata, not an error.
 
 ## Filter Syntax
 
@@ -145,6 +176,16 @@ Key response fields:
 }
 ```
 Then check `total_count` in the response for the full count.
+
+### Recover from an unresolved entity name
+```json
+{
+  "doctype": "Sales Order",
+  "filters": {"customer": "Grant Plastic"},
+  "fields": ["name", "customer", "grand_total"]
+}
+```
+Returns `count: 0` with `unresolved_filters.customer.suggestions: ["Grant Plastics Ltd."]`. Retry with the suggested name — do not report that the customer has no orders.
 
 ## Edge Cases
 

--- a/frappe_assistant_core/plugins/core/tools/list_documents.py
+++ b/frappe_assistant_core/plugins/core/tools/list_documents.py
@@ -129,6 +129,130 @@ def apply_default_docstatus(doctype: str, filters: Any) -> tuple:
     return {"docstatus": 1}, True
 
 
+# Ranked candidates offered per unmatched Link filter value.
+MAX_LINK_SUGGESTIONS = 5
+
+
+def equality_filter_pairs(filters: Any) -> List[tuple]:
+    """(fieldname, value) pairs for filters compared to a single value by equality.
+
+    Only these can be checked for existence — an operator like `like` or `in`
+    already expresses that the caller does not know the exact value.
+    """
+    pairs = []
+
+    if isinstance(filters, dict):
+        for fieldname, value in filters.items():
+            if isinstance(value, str):
+                pairs.append((fieldname, value))
+            elif isinstance(value, (list, tuple)) and len(value) == 2:
+                operator, operand = value
+                if isinstance(operator, str) and operator == "=" and isinstance(operand, str):
+                    pairs.append((fieldname, operand))
+        return pairs
+
+    if isinstance(filters, (list, tuple)):
+        conditions = [filters] if filters and isinstance(filters[0], str) else filters
+        for condition in conditions:
+            if not isinstance(condition, (list, tuple)) or len(condition) < 3:
+                continue
+            # ["doctype", "fieldname", op, value] or ["fieldname", op, value]
+            fieldname, operator, value = condition[1:4] if len(condition) >= 4 else condition[0:3]
+            if operator == "=" and isinstance(value, str):
+                pairs.append((fieldname, value))
+
+    return pairs
+
+
+def link_filter_targets(doctype: str, filters: Any) -> Dict[str, tuple]:
+    """Map fieldname -> (target DocType, value) for Link fields filtered by equality."""
+    pairs = equality_filter_pairs(filters)
+    if not pairs:
+        return {}
+
+    try:
+        meta = frappe.get_meta(doctype)
+    except Exception:
+        return {}
+
+    targets = {}
+    for fieldname, value in pairs:
+        if not value:
+            continue
+        field = meta.get_field(fieldname)
+        if not field or field.fieldtype != "Link" or not field.options:
+            continue
+        targets[fieldname] = (field.options, value)
+
+    return targets
+
+
+def link_suggestions(target_doctype: str, value: str) -> List[str]:
+    """Ranked candidate names for an unmatched Link value, via search_link resolution.
+
+    Falls back to the first word of a multi-word value, since search_link matches
+    on substrings and a typo late in the value would otherwise return nothing.
+    """
+    from .search_tools import SearchTools
+
+    queries = [value]
+    words = value.split()
+    if words and words[0] != value:
+        queries.append(words[0])
+
+    for query in queries:
+        response = SearchTools.search_link(doctype=target_doctype, query=query)
+        if not response.get("success"):
+            return []
+
+        suggestions = [
+            candidate.get("value") for candidate in response.get("results") or [] if candidate.get("value")
+        ]
+        if suggestions:
+            return suggestions[:MAX_LINK_SUGGESTIONS]
+
+    return []
+
+
+def resolve_unmatched_link_filters(doctype: str, filters: Any) -> Dict[str, Dict[str, Any]]:
+    """Explain a zero-row result caused by Link filter values that match no record.
+
+    "No records" and "that entity does not exist" are indistinguishable to a
+    consumer otherwise, so an approximate name passed straight into a filter reads
+    as a legitimate business answer. Only called when the result set is empty.
+    """
+    unresolved = {}
+
+    for fieldname, (target_doctype, value) in link_filter_targets(doctype, filters).items():
+        try:
+            if not frappe.db.exists("DocType", target_doctype):
+                continue
+
+            # Without read access on the target, neither existence nor candidates
+            # are ours to report.
+            if not frappe.has_permission(target_doctype, "read"):
+                continue
+
+            # The value resolves — zero rows is a real answer, not a bad filter.
+            if frappe.db.exists(target_doctype, value):
+                continue
+
+            unresolved[fieldname] = {
+                "value": value,
+                "matched": False,
+                "target_doctype": target_doctype,
+                "suggestions": link_suggestions(target_doctype, value),
+            }
+        except Exception as e:
+            # Diagnostics must never turn a successful query into a failure.
+            frappe.log_error(
+                title=_("Link Filter Resolution Error"),
+                message=f"Error resolving {doctype}.{fieldname}: {str(e)}",
+            )
+
+    return unresolved
+
+
 class DocumentList(BaseTool):
     """
     Tool for listing and searching Frappe documents.
@@ -143,7 +267,7 @@ class DocumentList(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "list_documents"
-        self.description = "Search and list Frappe documents with optional filtering. Use this when users want to find records, get lists of documents, or search for data. This is the primary tool for data exploration and discovery. For submittable DocTypes (invoices, orders, entries) only submitted documents are returned unless you pass docstatus explicitly."
+        self.description = "Search and list Frappe documents with optional filtering. Use this when users want to find records, get lists of documents, or search for data. This is the primary tool for data exploration and discovery. For submittable DocTypes (invoices, orders, entries) only submitted documents are returned unless you pass docstatus explicitly. If a query returns nothing because a Link filter value matches no record, the response carries unresolved_filters with ranked suggestions — check it before reporting that no data exists."
         self.requires_permission = None  # Permission checked dynamically per DocType
 
         self.inputSchema = {
@@ -292,6 +416,18 @@ class DocumentList(BaseTool):
                 "filters_applied": filters,
                 "message": message,
             }
+
+            # A zero-row result may mean the filter value itself never existed.
+            # Additive metadata only — the query still succeeded.
+            if not filtered_documents:
+                unresolved_filters = resolve_unmatched_link_filters(doctype, filters)
+                if unresolved_filters:
+                    result["unresolved_filters"] = unresolved_filters
+                    result["message"] += (
+                        f" — but these filter values match no record: "
+                        f"{', '.join(sorted(unresolved_filters))}. This is an unresolved filter, "
+                        "not an empty result. See unresolved_filters for candidates."
+                    )
 
             # Log successful access
             return result

--- a/frappe_assistant_core/tests/test_list_documents_unresolved_filters.py
+++ b/frappe_assistant_core/tests/test_list_documents_unresolved_filters.py
@@ -1,0 +1,406 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/228
+
+A Link-field filter value that matched no record produced count: 0 with
+success: true and nothing else. "Zero records" and "that entity does not exist"
+were indistinguishable, so an approximate name passed straight into a filter read
+as a legitimate business answer.
+
+Zero-row results now carry unresolved_filters with ranked search_link candidates
+for each Link value that resolves to nothing. Non-empty results are untouched and
+pay no extra query.
+"""
+
+from contextlib import ExitStack, contextmanager
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from frappe_assistant_core.plugins.core.tools.list_documents import (
+    DocumentList,
+    equality_filter_pairs,
+    link_filter_targets,
+    link_suggestions,
+    resolve_unmatched_link_filters,
+)
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+
+def link_meta(**fields):
+    """A meta stub whose get_field() answers from a {fieldname: fieldtype/options} map."""
+
+    def get_field(fieldname):
+        spec = fields.get(fieldname)
+        if not spec:
+            return None
+        fieldtype, options = spec
+        return MagicMock(fieldtype=fieldtype, options=options)
+
+    return MagicMock(is_submittable=0, get_field=get_field)
+
+
+@contextmanager
+def resolution_harness(existing=(), suggestions=None, has_permission=True, meta=None):
+    """Patch the metadata, existence and search_link lookups the resolver depends on.
+
+    `existing` names the records that resolve; anything else is unmatched.
+    `suggestions` maps a search_link query to the candidate values it returns.
+    """
+    suggestions = suggestions or {}
+
+    def db_exists(doctype, name=None, **kwargs):
+        if doctype == "DocType":
+            return True
+        return name in existing
+
+    def search_link(doctype, query, filters=None):
+        return {
+            "success": True,
+            "results": [{"value": value} for value in suggestions.get(query, [])],
+        }
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+                return_value=meta if meta is not None else link_meta(customer=("Link", "Customer")),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.db.exists",
+                side_effect=db_exists,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.has_permission",
+                return_value=has_permission,
+            )
+        )
+        search = stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.search_tools.SearchTools.search_link",
+                side_effect=search_link,
+            )
+        )
+        yield search
+
+
+@contextmanager
+def list_documents_harness(rows, meta=None, existing=(), suggestions=None):
+    """Run DocumentList.execute() end to end with permissions and queries mocked."""
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.core.security_config.validate_document_access",
+                return_value={"success": True, "role": "Default"},
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.core.security_config.filter_sensitive_fields",
+                side_effect=lambda doc, _doctype, _role: doc,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "frappe_assistant_core.plugins.core.tools.list_documents.frappe.session",
+                MagicMock(user="analyst@example.com"),
+            )
+        )
+        get_list = stack.enter_context(
+            patch("frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_list")
+        )
+        get_list.side_effect = [rows, [{"count": len(rows)}]]
+        search = stack.enter_context(
+            resolution_harness(existing=existing, suggestions=suggestions, meta=meta)
+        )
+        yield get_list, search
+
+
+class TestEqualityFilterPairs(BaseAssistantTest):
+    """Only equality comparisons against a single value can be existence-checked."""
+
+    def test_plain_string_values(self):
+        self.assertEqual(
+            equality_filter_pairs({"customer": "Acme", "status": "Open"}),
+            [("customer", "Acme"), ("status", "Open")],
+        )
+
+    def test_explicit_equality_operator(self):
+        self.assertEqual(equality_filter_pairs({"customer": ["=", "Acme"]}), [("customer", "Acme")])
+
+    def test_fuzzy_and_set_operators_excluded(self):
+        """`like` and `in` already say the caller does not know the exact value."""
+        for value in (["like", "%acme%"], ["in", ["A", "B"]], ["!=", "Acme"], [">", "2024-01-01"]):
+            self.assertEqual(equality_filter_pairs({"customer": value}), [])
+
+    def test_non_string_values_excluded(self):
+        self.assertEqual(equality_filter_pairs({"docstatus": 1, "grand_total": 100}), [])
+
+    def test_list_style_conditions(self):
+        self.assertEqual(
+            equality_filter_pairs([["customer", "=", "Acme"], ["status", "like", "%Open%"]]),
+            [("customer", "Acme")],
+        )
+
+    def test_doctype_qualified_conditions(self):
+        self.assertEqual(
+            equality_filter_pairs([["Sales Order", "customer", "=", "Acme"]]),
+            [("customer", "Acme")],
+        )
+
+    def test_unwrapped_condition(self):
+        self.assertEqual(equality_filter_pairs(["customer", "=", "Acme"]), [("customer", "Acme")])
+
+    def test_empty_filters(self):
+        for filters in ({}, [], None):
+            self.assertEqual(equality_filter_pairs(filters), [])
+
+
+class TestLinkFilterTargets(BaseAssistantTest):
+    """Only Link fields have a target DocType to resolve a value against."""
+
+    def test_link_field_resolves_to_its_target(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=link_meta(customer=("Link", "Customer"), status=("Select", None)),
+        ):
+            targets = link_filter_targets("Sales Order", {"customer": "Acme", "status": "Open"})
+
+        self.assertEqual(targets, {"customer": ("Customer", "Acme")})
+
+    def test_dynamic_link_and_data_fields_ignored(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=link_meta(party=("Dynamic Link", "party_type"), reference=("Data", None)),
+        ):
+            targets = link_filter_targets("Payment Entry", {"party": "Acme", "reference": "X"})
+
+        self.assertEqual(targets, {})
+
+    def test_unknown_field_ignored(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=link_meta(),
+        ):
+            self.assertEqual(link_filter_targets("Sales Order", {"nope": "Acme"}), {})
+
+    def test_empty_value_ignored(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+            return_value=link_meta(customer=("Link", "Customer")),
+        ):
+            self.assertEqual(link_filter_targets("Sales Order", {"customer": ""}), {})
+
+
+class TestLinkSuggestions(BaseAssistantTest):
+    """Candidates come from the existing search_link resolution."""
+
+    def test_full_value_match(self):
+        with resolution_harness(suggestions={"Acme Corp": ["Acme Corporation", "Acme Corp Ltd"]}):
+            self.assertEqual(
+                link_suggestions("Customer", "Acme Corp"),
+                ["Acme Corporation", "Acme Corp Ltd"],
+            )
+
+    def test_first_word_fallback_for_late_typos(self):
+        """search_link matches on substrings, so a typo after the first word finds nothing."""
+        with resolution_harness(suggestions={"Acme": ["Acme Corporation"]}) as search:
+            self.assertEqual(link_suggestions("Customer", "Acme Corpp"), ["Acme Corporation"])
+
+        self.assertEqual([call.kwargs["query"] for call in search.call_args_list], ["Acme Corpp", "Acme"])
+
+    def test_no_fallback_when_full_value_matches(self):
+        with resolution_harness(suggestions={"Acme Corp": ["Acme Corporation"]}) as search:
+            link_suggestions("Customer", "Acme Corp")
+
+        self.assertEqual(search.call_count, 1, "a successful lookup must not be retried")
+
+    def test_single_word_value_is_looked_up_once(self):
+        with resolution_harness(suggestions={}) as search:
+            self.assertEqual(link_suggestions("Customer", "Acme"), [])
+
+        self.assertEqual(search.call_count, 1)
+
+    def test_suggestions_are_capped(self):
+        many = [f"Candidate {i}" for i in range(20)]
+        with resolution_harness(suggestions={"Acme": many}):
+            self.assertEqual(len(link_suggestions("Customer", "Acme")), 5)
+
+    def test_failed_search_yields_no_suggestions(self):
+        with patch(
+            "frappe_assistant_core.plugins.core.tools.search_tools.SearchTools.search_link",
+            return_value={"success": False, "error": "No read permission"},
+        ):
+            self.assertEqual(link_suggestions("Customer", "Acme"), [])
+
+
+class TestResolveUnmatchedLinkFilters(BaseAssistantTest):
+    """The resolver reports only values that genuinely resolve to nothing."""
+
+    def test_unmatched_value_is_reported_with_candidates(self):
+        with resolution_harness(
+            existing=("Acme Corporation",), suggestions={"Acme Corp": ["Acme Corporation"]}
+        ):
+            unresolved = resolve_unmatched_link_filters("Sales Order", {"customer": "Acme Corp"})
+
+        self.assertEqual(
+            unresolved,
+            {
+                "customer": {
+                    "value": "Acme Corp",
+                    "matched": False,
+                    "target_doctype": "Customer",
+                    "suggestions": ["Acme Corporation"],
+                }
+            },
+        )
+
+    def test_existing_value_is_not_reported(self):
+        """Genuinely no matching records — the filter value itself is fine."""
+        with resolution_harness(existing=("Acme Corp",), suggestions={"Acme Corp": ["Acme Corp"]}):
+            unresolved = resolve_unmatched_link_filters("Sales Order", {"customer": "Acme Corp"})
+
+        self.assertEqual(unresolved, {})
+
+    def test_unmatched_value_without_candidates_still_reported(self):
+        """Knowing the value does not exist is the useful half of the signal."""
+        with resolution_harness(existing=(), suggestions={}):
+            unresolved = resolve_unmatched_link_filters("Sales Order", {"customer": "Zzz"})
+
+        self.assertEqual(unresolved["customer"]["matched"], False)
+        self.assertEqual(unresolved["customer"]["suggestions"], [])
+
+    def test_multiple_link_filters_resolved_independently(self):
+        meta = link_meta(customer=("Link", "Customer"), item_code=("Link", "Item"))
+        with resolution_harness(
+            existing=("Widget",),
+            suggestions={"Acme Corp": ["Acme Corporation"]},
+            meta=meta,
+        ):
+            unresolved = resolve_unmatched_link_filters(
+                "Sales Order", {"customer": "Acme Corp", "item_code": "Widget"}
+            )
+
+        self.assertEqual(list(unresolved), ["customer"], "only the unmatched filter is reported")
+        self.assertEqual(unresolved["customer"]["suggestions"], ["Acme Corporation"])
+
+    def test_no_read_permission_reports_nothing(self):
+        """Existence of a record in an unreadable DocType is not ours to disclose."""
+        with resolution_harness(existing=(), has_permission=False):
+            unresolved = resolve_unmatched_link_filters("Sales Order", {"customer": "Acme Corp"})
+
+        self.assertEqual(unresolved, {})
+
+    def test_resolution_failure_is_swallowed(self):
+        """Diagnostics must never turn a successful query into a failure."""
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "frappe_assistant_core.plugins.core.tools.list_documents.frappe.get_meta",
+                    return_value=link_meta(customer=("Link", "Customer")),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "frappe_assistant_core.plugins.core.tools.list_documents.frappe.db.exists",
+                    side_effect=RuntimeError("boom"),
+                )
+            )
+            stack.enter_context(
+                patch("frappe_assistant_core.plugins.core.tools.list_documents.frappe.log_error")
+            )
+            unresolved = resolve_unmatched_link_filters("Sales Order", {"customer": "Acme Corp"})
+
+        self.assertEqual(unresolved, {})
+
+
+class TestListDocumentsUnresolvedFilters(BaseAssistantTest):
+    """End-to-end behaviour of the zero-row path."""
+
+    def test_zero_rows_with_unmatched_link_filter_returns_suggestions(self):
+        with list_documents_harness(
+            rows=[],
+            existing=("Acme Corporation",),
+            suggestions={"Acme Corp": ["Acme Corporation"]},
+        ) as (_get_list, _search):
+            result = DocumentList().execute({"doctype": "Sales Order", "filters": {"customer": "Acme Corp"}})
+
+        self.assertTrue(result["success"], "an unresolved filter is not an error")
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(result["unresolved_filters"]["customer"]["suggestions"], ["Acme Corporation"])
+        self.assertIn("unresolved filter", result["message"])
+
+    def test_zero_rows_with_resolvable_link_filter_stays_quiet(self):
+        with list_documents_harness(rows=[], existing=("Acme Corp",)) as (_get_list, _search):
+            result = DocumentList().execute({"doctype": "Sales Order", "filters": {"customer": "Acme Corp"}})
+
+        self.assertEqual(result["count"], 0)
+        self.assertNotIn("unresolved_filters", result)
+        self.assertNotIn("unresolved filter", result["message"])
+
+    def test_non_empty_result_incurs_no_extra_queries(self):
+        with list_documents_harness(rows=[{"name": "SO-0001", "customer": "Acme Corp"}], existing=()) as (
+            get_list,
+            search,
+        ):
+            result = DocumentList().execute({"doctype": "Sales Order", "filters": {"customer": "Acme Corp"}})
+
+        self.assertEqual(result["count"], 1)
+        self.assertNotIn("unresolved_filters", result)
+        search.assert_not_called()
+        self.assertEqual(get_list.call_count, 2, "only the data and count queries")
+
+    def test_zero_rows_without_link_filters_stays_quiet(self):
+        with list_documents_harness(rows=[], existing=()) as (_get_list, search):
+            result = DocumentList().execute({"doctype": "Sales Order", "filters": {"status": "Closed"}})
+
+        self.assertNotIn("unresolved_filters", result)
+        search.assert_not_called()
+
+    def test_multiple_unmatched_link_filters_in_one_call(self):
+        meta = link_meta(customer=("Link", "Customer"), item_code=("Link", "Item"))
+        with list_documents_harness(
+            rows=[],
+            meta=meta,
+            existing=(),
+            suggestions={"Acme Corp": ["Acme Corporation"], "Widgt": ["Widget"]},
+        ) as (_get_list, _search):
+            result = DocumentList().execute(
+                {
+                    "doctype": "Sales Order",
+                    "filters": {"customer": "Acme Corp", "item_code": "Widgt"},
+                }
+            )
+
+        self.assertEqual(sorted(result["unresolved_filters"]), ["customer", "item_code"])
+        self.assertEqual(result["unresolved_filters"]["item_code"]["suggestions"], ["Widget"])
+        self.assertEqual(result["unresolved_filters"]["customer"]["target_doctype"], "Customer")
+
+    def test_real_metadata_link_target_lookup(self):
+        """Sanity-check target resolution against live metadata rather than a mock."""
+        if not frappe.db.exists("DocType", "Sales Order"):
+            self.skipTest("ERPNext not installed")
+
+        self.assertEqual(
+            link_filter_targets("Sales Order", {"customer": "Whatever"}),
+            {"customer": ("Customer", "Whatever")},
+        )


### PR DESCRIPTION
Fixes #228

> **Stacked on #231.** Base is `bug/227-list-documents-docstatus-default` so the diff shows only this issue's changes. GitHub retargets it to `develop` when #231 merges — ping me and I'll rebase if #231 is squash-merged.

## Problem

A Link-field filter value that matched no record returned `count: 0` with `success: true` and nothing else. "Zero records" and "that entity does not exist" were indistinguishable, so an approximate name passed straight into a filter read as a legitimate business answer — *"this customer has no orders"* when no such customer exists.

`search_link` already resolves near-misses well. The gap was only on the path that bypasses it.

## Change

When a query returns zero rows, `resolve_unmatched_link_filters()` checks each Link filter value and adds `unresolved_filters` for the ones that resolve to nothing:

```json
{
  "success": true,
  "count": 0,
  "unresolved_filters": {
    "customer": {
      "value": "Grant Plastic",
      "matched": false,
      "target_doctype": "Customer",
      "suggestions": ["Grant Plastics Ltd."]
    }
  }
}
```

`success` stays `true` and `count` stays `0` — additive metadata, not an error. `target_doctype` was added to the shape in the issue so the model can call `search_link` itself to go deeper.

Scope and guards:

- **Nothing runs on the happy path.** The lookups only fire when the result set is empty.
- **Values that exist are not reported**, so absence of the key confirms a genuinely empty result.
- **Only equality comparisons** are checked — `like`, `in`, `!=` already say the caller doesn't know the exact value. All filter forms are handled (dict, `["=", v]`, list-of-conditions, doctype-qualified, unwrapped).
- **Link fields only.** `Dynamic Link` has no static target; `Select`/`Data` have nothing to resolve against.
- **No disclosure without read access.** A target DocType the user can't read is skipped entirely, so neither existence nor candidates leak.
- **Diagnostics can't break the query.** Any failure in the resolver is logged and swallowed; the successful result is still returned.
- Candidates are capped at 5 and ranked as `search_link` ranks them.

### One deviation worth reviewing

`search_link` matches on substrings, so a typo *after* the first word finds nothing — the exact case the issue is about. If the full value returns no candidates and it has more than one word, the lookup retries with the first word only. Bounded at two lookups per unresolved filter, and only ever on an already-empty result.

Without it: `"Grant Plasticz Limited"` → `suggestions: []`. With it: → `["Grant Plastics Ltd."]`.

## Verification

Live instance, `Sales Order`:

| Filter | `count` | Result |
|---|---|---|
| `{"customer": "Grant Plastic"}` | 0 | `unresolved_filters.customer.suggestions: ["Grant Plastics Ltd."]` |
| `{"customer": "Grant Plastics Ltd."}` | 2 | no `unresolved_filters`, no extra query |
| `{"customer": "Grant Plasticz Limited"}` | 0 | `["Grant Plastics Ltd."]` via first-word fallback |
| `{"customer": "Grant Plastic", "territory": "Rest of Wrld"}` | 0 | both reported — `["Grant Plastics Ltd."]`, `["Rest Of The World"]` |
| `{"customer": ["like", "%Grant%"]}` | 2 | skipped, as intended |

30 new tests in `test_list_documents_unresolved_filters.py`. Full suite: 253 passed. `pre-commit run` clean.

## Acceptance criteria

- [x] Zero-result query with an unmatched Link filter returns `unresolved_filters` with ranked suggestions
- [x] Zero-result query where the Link value *does* exist (genuinely no matching records) does not return suggestions
- [x] Non-empty result sets incur no additional queries
- [x] Works across multiple Link filters in a single call
- [x] Regression test for each case
