### PR TITLE
fix: validate report filters against the report's own declared contract

### DIFF
--- a/docs/skills/generate_report.md
+++ b/docs/skills/generate_report.md
@@ -30,6 +30,43 @@ Returns: `{ reports: [{ name, report_name, report_type, module, is_standard, dis
 
 Returns filter definitions with field types, required flags, and valid options.
 
+### Filter values are per-report, never per-fieldname
+
+`generate_report` validates your filters against **the definitions this report declares** — the same ones `report_requirements` returns. Two reports can give the same filter name completely different meanings, so never carry a value over from one report to another.
+
+`range` is the clearest example:
+
+| Report | `range` fieldtype | Accepted values |
+|--------|-------------------|-----------------|
+| Accounts Receivable / Payable (+ Summary) | `Data` | ageing buckets, e.g. `"30, 60, 90, 120"` |
+| Stock Ageing | `Data` | ageing buckets, e.g. `"30, 60, 90"` |
+| Sales Analytics, Stock Analytics | `Select` | `Weekly`, `Monthly`, `Quarterly`, `Half-Yearly`, `Yearly` |
+| Website Analytics | `Select` | `Daily`, `Weekly`, `Monthly` |
+| Sales Pipeline Analytics | `Select` | `Monthly`, `Quarterly` |
+
+For a value-constrained filter (`Select`, `Autocomplete`), `options` is always an explicit list of the accepted values — use one of them verbatim. For a `Link` filter, `options` is the target DocType and the value must be an existing record name.
+
+**Every advertised `default` is guaranteed executable.** Passing the defaults `report_requirements` returns will never be rejected as an invalid value, and omitting a filter applies that same default.
+
+When a value is rejected, `validation_errors` names the accepted values and `error_details` carries them as structured data:
+
+```json
+{
+  "success": false,
+  "validation_errors": ["Invalid range: 'Weekly'. Must be one of: Monthly, Quarterly"],
+  "error_details": [
+    {
+      "fieldname": "range",
+      "type": "invalid_option",
+      "value": "Weekly",
+      "accepted_values": ["Monthly", "Quarterly"]
+    }
+  ]
+}
+```
+
+`type` is one of `invalid_option`, `unknown_record` (a Link value with no such record — `suggestions` offers candidates), or `invalid_date`.
+
 ## generate_report Parameters
 
 | Parameter | Type | Required | Default | Description |
@@ -42,9 +79,10 @@ Returns filter definitions with field types, required flags, and valid options.
 
 1. **Always call `report_requirements` first** — missing mandatory filters often cause empty results or errors. The tool auto-defaults dates and company, but these defaults may not match what you need.
 2. **Use exact values for Link filters** — company names, customer names, etc. must match exactly what's in the database.
-3. **Use `report_list` to find reports** — don't guess report names. Common modules: Accounts, Selling, Buying, Stock, HR.
-4. **Script Reports are most powerful** — they have custom business logic. Query Reports are simpler SQL-based reports.
-5. **Use `format: "csv"` or `"excel"` for exports** — returns downloadable file links.
+3. **Take Select values from that report's own `options`** — the same filter name can accept different values in a different report.
+4. **Use `report_list` to find reports** — don't guess report names. Common modules: Accounts, Selling, Buying, Stock, HR.
+5. **Script Reports are most powerful** — they have custom business logic. Query Reports are simpler SQL-based reports.
+6. **Use `format: "csv"` or `"excel"` for exports** — returns downloadable file links.
 
 ## Common Workflow
 

--- a/frappe_assistant_core/plugins/core/tools/generate_report.py
+++ b/frappe_assistant_core/plugins/core/tools/generate_report.py
@@ -55,7 +55,7 @@ class GenerateReport(BaseTool):
                 "filters": {
                     "type": "object",
                     "default": {},
-                    "description": "Filter key-value pairs. Get valid keys and values from report_requirements first. Dates: YYYY-MM-DD. Link fields (company, customer) must be exact DB names. Select fields must match allowed options exactly.",
+                    "description": "Filter key-value pairs. Get valid keys and values from report_requirements first — values are validated against that report's own declared filters, and the same filter name can accept different values in a different report. Dates: YYYY-MM-DD. Link fields (company, customer) must be exact DB names. Select fields must match that report's advertised options exactly.",
                 },
                 "format": {
                     "type": "string",

--- a/frappe_assistant_core/plugins/core/tools/report_requirements.py
+++ b/frappe_assistant_core/plugins/core/tools/report_requirements.py
@@ -27,6 +27,66 @@ from frappe import _
 
 from frappe_assistant_core.core.base_tool import BaseTool
 
+# Fieldtypes whose `options` is a set of accepted values rather than a target
+# DocType. Everything else (Link, MultiSelectList) points at a DocType instead.
+VALUE_CONSTRAINED_FIELDTYPES = {"Select", "Autocomplete"}
+
+# A JavaScript string literal in each of its three quotings. Empty strings have
+# to match as well: a leading "" in an options array — the "no selection" entry —
+# threw naive quote-pairing off by one, so the separators between values were
+# captured instead of the values themselves (issue #229).
+_JS_STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"' r"|'((?:[^'\\]|\\.)*)'" r"|`((?:[^`\\]|\\.)*)`")
+
+
+def _extract_js_string_literals(text: str) -> list:
+    """Every string literal in a fragment of JavaScript, in source order."""
+    return [
+        next((group for group in match.groups() if group is not None), "")
+        for match in _JS_STRING_LITERAL.finditer(text)
+    ]
+
+
+def normalize_filter_options(filter_def: Dict[str, Any]) -> Dict[str, Any]:
+    """Express a value-constrained filter's accepted values as an explicit list.
+
+    Report JS declares Select options three ways: an array of strings, an array
+    of ``{value, label}`` objects, and a newline-delimited string. Only the first
+    two arrived as a list — the third reached callers as an opaque
+    ``"Monthly\\nQuarterly"``, so the same contract had two shapes and a
+    constrained value set could not be read off the advertised definition
+    (issue #229).
+
+    Mutates and returns the filter definition.
+    """
+    if filter_def.get("fieldtype") not in VALUE_CONSTRAINED_FIELDTYPES:
+        return filter_def
+
+    options = filter_def.get("options")
+    if isinstance(options, str):
+        # Read from a .js file, so an escaped newline arrives as a literal
+        # backslash-n; a child-table row carries a real newline.
+        filter_def["options"] = [value.strip() for value in re.split(r"\\n|\n", options) if value.strip()]
+    elif isinstance(options, (list, tuple)):
+        filter_def["options"] = [str(value).strip() for value in options if str(value).strip()]
+
+    return filter_def
+
+
+def discover_filter_definitions(report_doc) -> Dict[str, Dict[str, Any]]:
+    """The report's filter contract as ``{fieldname: definition}``.
+
+    The single entry point shared by ``report_requirements``, which advertises the
+    contract, and ``generate_report``, which validates against it. Deriving both
+    from here is what stops the two tools disagreeing about their own contract.
+    """
+    tool = ReportRequirements()
+    parsed, _diagnostics = tool._discover_report_filters(report_doc.name, report_doc)
+    return {
+        filter_def["fieldname"]: filter_def
+        for filter_def in (parsed or {}).get("filters", [])
+        if filter_def.get("fieldname")
+    }
+
 
 class ReportRequirements(BaseTool):
     """
@@ -43,7 +103,7 @@ class ReportRequirements(BaseTool):
     def __init__(self):
         super().__init__()
         self.name = "report_requirements"
-        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. Check 'filter_discovery_status': 'no_filters_declared' means the report genuinely takes no filters, while 'unresolved' means discovery failed and 'discovery_diagnostics' explains why. NOTE: Report Builder reports store a saved column/filter configuration rather than a filter contract and are not yet fully supported."
+        self.description = "Get report metadata including required and optional filters, columns, and execution requirements for Script Reports, Query Reports, and Custom Reports. Use this tool before executing reports to understand what filters are mandatory, what exact filter values are valid, and how to structure the report request. This prevents filter errors and helps plan successful report execution. Returns complete report metadata including filter definitions with field types (Link, Select, Date), valid enum options for select fields, column structure, report type, and capabilities. For a value-constrained filter (Select, Autocomplete) 'options' is an explicit list of accepted values, and every 'default' returned here is guaranteed to be accepted by generate_report. Filter contracts are per-report: the same filter name can mean different things in different reports (e.g. 'range' is an ageing bucket string like '30, 60, 90, 120' on the AR/AP reports but a periodicity Select elsewhere), so never reuse a value across reports. IMPORTANT: Use this FIRST before calling generate_report to understand what exact filter values are needed - Link fields require exact database names (e.g., exact Company name, Customer name), Select fields show valid enum values. Essential when generate_report returns filter errors or when planning complex report execution. Check 'filter_discovery_status': 'no_filters_declared' means the report genuinely takes no filters, while 'unresolved' means discovery failed and 'discovery_diagnostics' explains why. NOTE: Report Builder reports store a saved column/filter configuration rather than a filter contract and are not yet fully supported."
         self.requires_permission = None  # Permission checked dynamically per report
 
         self.inputSchema = {
@@ -210,12 +270,11 @@ class ReportRequirements(BaseTool):
             if label and label != fieldname:
                 description = f"{fieldname} ({label})"
 
-            # Add type and options info
-            if fieldtype == "Select" and options and isinstance(options, list):
-                options_str = ", ".join(options[:3])  # Show first 3 options
-                if len(options) > 3:
-                    options_str += f", ... ({len(options)} options)"
-                description += f" - Select: {options_str}"
+            # Add type and options info. A constrained value set is listed in
+            # full — truncating it hides values the caller is required to choose
+            # from, which is the whole point of advertising them (issue #229).
+            if fieldtype in VALUE_CONSTRAINED_FIELDTYPES and options and isinstance(options, list):
+                description += f" - {fieldtype}, one of: {', '.join(options)}"
             elif fieldtype == "Link" and options:
                 description += f" - Link to {options}"
             elif fieldtype:
@@ -504,7 +563,11 @@ class ReportRequirements(BaseTool):
 
     @staticmethod
     def _build_parsed_filter_result(filters: list[Dict[str, Any]]) -> Dict[str, Any]:
-        """Build the canonical parsed-filter payload and preserve conditional requirements."""
+        """Build the canonical parsed-filter payload and preserve conditional requirements.
+
+        Every discovery source funnels through here, so it is also where a
+        constrained value set is normalised to an explicit list.
+        """
         required_filters = []
         conditional_required_filters = []
         optional_filters = []
@@ -513,6 +576,7 @@ class ReportRequirements(BaseTool):
             fieldname = filter_def.get("fieldname")
             if not fieldname:
                 continue
+            normalize_filter_options(filter_def)
             if filter_def.get("required"):
                 required_filters.append(fieldname)
             elif filter_def.get("mandatory_depends_on"):
@@ -937,7 +1001,7 @@ class ReportRequirements(BaseTool):
                         options_str,
                     )
                     if not option_values:
-                        option_values = re.findall(r'["\']([^"\']+)["\']', options_str)
+                        option_values = _extract_js_string_literals(options_str)
                     filter_def["options"] = option_values
                 else:
                     # String format (e.g., Link to DocType)

--- a/frappe_assistant_core/plugins/core/tools/report_tools.py
+++ b/frappe_assistant_core/plugins/core/tools/report_tools.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, List
 import frappe
 from frappe import _
 
+from .report_requirements import VALUE_CONSTRAINED_FIELDTYPES, discover_filter_definitions
+
 
 class ReportTools:
     """
@@ -54,13 +56,18 @@ class ReportTools:
             # Get report document
             report_doc = frappe.get_doc("Report", report_name)
 
+            # Resolve the report's declared filter contract once, then use it for
+            # both validation and defaulting so every code path agrees on it.
+            definitions = ReportTools._filter_definitions(report_doc)
+
             # Validate filters before execution
-            validation_result = ReportTools._validate_filters(filters or {}, report_doc)
+            validation_result = ReportTools._validate_filters(filters or {}, report_doc, definitions)
             if not validation_result.get("valid"):
                 return {
                     "success": False,
                     "error": "Invalid filter values provided",
                     "validation_errors": validation_result.get("errors", []),
+                    "error_details": validation_result.get("error_details", []),
                     "suggestions": validation_result.get("suggestions", []),
                 }
 
@@ -73,7 +80,7 @@ class ReportTools:
             if report_doc.report_type == "Query Report":
                 result = ReportTools._execute_query_report(report_doc, effective_filters)
             elif report_doc.report_type == "Script Report":
-                result = ReportTools._execute_script_report(report_doc, effective_filters)
+                result = ReportTools._execute_script_report(report_doc, effective_filters, definitions)
             elif report_doc.report_type == "Report Builder":
                 return {
                     "success": False,
@@ -485,7 +492,7 @@ class ReportTools:
             raise e
 
     @staticmethod
-    def _execute_script_report(report_doc, filters):
+    def _execute_script_report(report_doc, filters, definitions=None):
         """Execute a Script Report"""
         from frappe.desk.query_report import run
 
@@ -567,8 +574,8 @@ class ReportTools:
             if "quotation trends" in report_name_lower and "based_on" not in filters:
                 filters["based_on"] = "Item"
 
-            # Apply default values from JavaScript filter definitions
-            filters = ReportTools._apply_filter_defaults(report_doc, filters)
+            # Apply the defaults the report itself declares
+            filters = ReportTools._apply_filter_defaults(report_doc, filters, definitions)
 
             # Final cleanup - ensure all filter values are strings or proper types
             final_filters = {}
@@ -617,193 +624,149 @@ class ReportTools:
             }
 
     @staticmethod
-    def _validate_filters(filters: Dict[str, Any], report_doc) -> Dict[str, Any]:
-        """Validate filter values against database to catch invalid references early"""
+    def _validate_filters(filters: Dict[str, Any], report_doc, definitions=None) -> Dict[str, Any]:
+        """Validate filter values against the report's own declared filter contract.
+
+        Accepted values come from the same discovery that ``report_requirements``
+        advertises, so the two tools cannot disagree about their own contract.
+
+        A hardcoded fieldname -> values map used to stand in for this, and it was
+        wrong in both directions. ``range`` alone means four different things
+        across the standard apps: ageing buckets as Data ("30, 60, 90, 120") on
+        the AR/AP and Stock Ageing reports, Weekly..Yearly on Sales/Stock
+        Analytics, Daily|Weekly|Monthly on Website Analytics, and Monthly|Quarterly
+        on Sales Pipeline Analytics. The map rejected the first group's advertised
+        defaults outright and accepted values the last two do not offer
+        (issue #229).
+
+        A filter the report does not declare is left alone: guessing is what
+        created the mismatch, and the report itself reports a real error.
+        """
         errors = []
         suggestions = []
+        details = []
 
-        # Common Link field filters to validate
-        link_validations = {
-            "company": "Company",
-            "customer": "Customer",
-            "supplier": "Supplier",
-            "item": "Item",
-            "project": "Project",
-            "cost_center": "Cost Center",
-            "warehouse": "Warehouse",
-        }
+        if definitions is None:
+            definitions = ReportTools._filter_definitions(report_doc)
 
-        for filter_key, doctype in link_validations.items():
-            if filter_key in filters and filters[filter_key]:
-                filter_value = filters[filter_key]
+        for filter_key, filter_value in filters.items():
+            if not filter_value:
+                continue
 
-                # Skip validation for list values (used in group reports)
+            definition = definitions.get(filter_key)
+            if not definition:
+                continue
+
+            fieldtype = definition.get("fieldtype")
+            options = definition.get("options")
+
+            # A constrained value set: validate membership against this report's
+            # own options, and name them in the error.
+            if fieldtype in VALUE_CONSTRAINED_FIELDTYPES and isinstance(options, list) and options:
                 if isinstance(filter_value, list):
-                    continue
-
-                # Check if the referenced document exists
-                if not frappe.db.exists(doctype, filter_value):
-                    errors.append(f"Invalid {filter_key}: '{filter_value}' does not exist in {doctype}")
-
-                    # Try to find similar names to suggest
-                    try:
-                        similar = frappe.get_all(
-                            doctype, filters={"name": ["like", f"%{filter_value}%"]}, fields=["name"], limit=3
-                        )
-                        if similar:
-                            suggestions.append(
-                                f"Did you mean one of these {doctype} names? {', '.join([s.name for s in similar])}"
-                            )
-                        else:
-                            # If no similar matches, show first few valid options
-                            valid_options = frappe.get_all(doctype, fields=["name"], limit=5)
-                            if valid_options:
-                                suggestions.append(
-                                    f"Valid {doctype} names include: {', '.join([v.name for v in valid_options])}"
-                                )
-                    except Exception:
-                        pass
-
-        # Validate Select field options
-        select_validations = {
-            "tree_type": [
-                "Customer",
-                "Supplier",
-                "Item",
-                "Customer Group",
-                "Supplier Group",
-                "Item Group",
-                "Territory",
-                "Order Type",
-                "Project",
-            ],
-            "doc_type": [
-                "Sales Invoice",
-                "Sales Order",
-                "Quotation",
-                "Purchase Invoice",
-                "Purchase Order",
-                "Purchase Receipt",
-                "Delivery Note",
-            ],
-            "value_quantity": ["Value", "Quantity"],
-            "range": ["Weekly", "Monthly", "Quarterly", "Half-Yearly", "Yearly"],
-        }
-
-        for filter_key, valid_options in select_validations.items():
-            if filter_key in filters and filters[filter_key]:
-                filter_value = filters[filter_key]
-                if filter_value not in valid_options:
+                    continue  # multi-value selection, not a single enum choice
+                if filter_value not in options:
                     errors.append(
-                        f"Invalid {filter_key}: '{filter_value}'. Must be one of: {', '.join(valid_options)}"
+                        f"Invalid {filter_key}: '{filter_value}'. Must be one of: {', '.join(options)}"
                     )
+                    details.append(
+                        {
+                            "fieldname": filter_key,
+                            "type": "invalid_option",
+                            "value": filter_value,
+                            "accepted_values": options,
+                        }
+                    )
+                continue
 
-        # Validate date formats
-        date_fields = ["from_date", "to_date", "posting_date", "transaction_date"]
-        for date_field in date_fields:
-            if date_field in filters and filters[date_field]:
+            # A Link target: validate the referenced record exists. `options` is
+            # only a DocType when the report says so — on some filters it names a
+            # companion fieldname instead (party -> party_type).
+            if fieldtype == "Link" and isinstance(options, str) and options:
+                if isinstance(filter_value, list):
+                    continue  # list values are used by grouped reports
+                if not frappe.db.exists("DocType", options):
+                    continue
+                if not frappe.db.exists(options, filter_value):
+                    errors.append(f"Invalid {filter_key}: '{filter_value}' does not exist in {options}")
+                    details.append(
+                        {
+                            "fieldname": filter_key,
+                            "type": "unknown_record",
+                            "value": filter_value,
+                            "target_doctype": options,
+                        }
+                    )
+                    suggestions.extend(ReportTools._link_value_suggestions(options, filter_value))
+                continue
+
+            if fieldtype in ("Date", "Datetime"):
                 try:
                     from frappe.utils import getdate
 
-                    getdate(filters[date_field])
+                    getdate(filter_value)
                 except Exception:
-                    errors.append(
-                        f"Invalid {date_field}: '{filters[date_field]}'. Expected format: YYYY-MM-DD"
-                    )
+                    errors.append(f"Invalid {filter_key}: '{filter_value}'. Expected format: YYYY-MM-DD")
+                    details.append({"fieldname": filter_key, "type": "invalid_date", "value": filter_value})
 
-        return {"valid": len(errors) == 0, "errors": errors, "suggestions": suggestions}
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "suggestions": suggestions,
+            "error_details": details,
+        }
 
     @staticmethod
-    def _apply_filter_defaults(report_doc, filters):
-        """Apply default filter values from JavaScript filter definitions for Script Reports"""
-        import os
-        import re
-
-        # Only apply for Script Reports
-        if report_doc.report_type != "Script Report":
-            return filters
-
+    def _filter_definitions(report_doc) -> Dict[str, Any]:
+        """The report's declared filter contract, or {} when discovery finds nothing."""
         try:
-            # Get the report's JavaScript file path
-            module_name = report_doc.module
-            report_name = report_doc.name
-            report_folder = report_name.lower().replace(" ", "_").replace("-", "_")
-            module_folder = module_name.lower().replace(" ", "_")
+            return discover_filter_definitions(report_doc)
+        except Exception as e:
+            frappe.log_error(
+                title=_("Report Filter Discovery Error"),
+                message=f"Error discovering filters for {report_doc.name}: {str(e)}",
+            )
+            return {}
 
-            # Search for the JS file in installed apps
-            for app in frappe.get_installed_apps():
-                app_path = frappe.get_app_path(app)
-                js_path = os.path.join(
-                    app_path, module_folder, "report", report_folder, f"{report_folder}.js"
-                )
+    @staticmethod
+    def _link_value_suggestions(doctype: str, filter_value) -> list:
+        """Name-like candidates for an unknown Link value, or valid examples."""
+        try:
+            similar = frappe.get_all(
+                doctype, filters={"name": ["like", f"%{filter_value}%"]}, fields=["name"], limit=3
+            )
+            if similar:
+                return [f"Did you mean one of these {doctype} names? {', '.join([s.name for s in similar])}"]
 
-                if os.path.exists(js_path):
-                    # nosemgrep: frappe-security-file-traversal — path built from frappe.get_app_path + report metadata, not user input
-                    with open(js_path, encoding="utf-8") as f:
-                        js_content = f.read()
+            valid_options = frappe.get_all(doctype, fields=["name"], limit=5)
+            if valid_options:
+                return [f"Valid {doctype} names include: {', '.join([v.name for v in valid_options])}"]
+        except Exception:
+            pass
 
-                    # Extract filter definitions
-                    filters_start = js_content.find("filters:")
-                    if filters_start == -1:
-                        continue
+        return []
 
-                    # Find the filter array using bracket counting
-                    bracket_start = js_content.find("[", filters_start)
-                    if bracket_start == -1:
-                        continue
+    @staticmethod
+    def _apply_filter_defaults(report_doc, filters, definitions=None):
+        """Apply the default filter values the report itself declares.
 
-                    bracket_count = 0
-                    bracket_end = -1
-                    for i in range(bracket_start, len(js_content)):
-                        if js_content[i] == "[":
-                            bracket_count += 1
-                        elif js_content[i] == "]":
-                            bracket_count -= 1
-                            if bracket_count == 0:
-                                bracket_end = i
-                                break
+        Uses the shared discovery rather than a private parser. A second
+        hand-rolled JS regex lived here and could disagree with the definitions
+        report_requirements advertises — the same class of divergence as the
+        validator's hardcoded value map (issue #229).
+        """
+        try:
+            if definitions is None:
+                definitions = ReportTools._filter_definitions(report_doc)
 
-                    if bracket_end == -1:
-                        continue
-
-                    filters_text = js_content[bracket_start + 1 : bracket_end]
-
-                    # Parse filter objects
-                    filter_objects = []
-                    brace_count = 0
-                    current_obj_start = None
-
-                    for i, char in enumerate(filters_text):
-                        if char == "{":
-                            if brace_count == 0:
-                                current_obj_start = i
-                            brace_count += 1
-                        elif char == "}":
-                            brace_count -= 1
-                            if brace_count == 0 and current_obj_start is not None:
-                                obj_content = filters_text[current_obj_start + 1 : i]
-                                filter_objects.append(obj_content)
-                                current_obj_start = None
-
-                    # Extract default values from each filter
-                    for filter_obj in filter_objects:
-                        # Extract fieldname
-                        fieldname_match = re.search(r'fieldname:\s*["\']([^"\']+)["\']', filter_obj)
-                        if not fieldname_match:
-                            continue
-                        fieldname = fieldname_match.group(1)
-
-                        # Skip if filter already has a value
-                        if fieldname in filters and filters[fieldname] is not None:
-                            continue
-
-                        # Extract default value
-                        default_match = re.search(r'default:\s*["\']([^"\']+)["\']', filter_obj)
-                        if default_match:
-                            default_value = default_match.group(1)
-                            filters[fieldname] = default_value
-
-                    break  # Found and processed the JS file
+            for fieldname, definition in definitions.items():
+                default = definition.get("default")
+                if default in (None, ""):
+                    continue
+                # Never override a value the caller supplied.
+                if filters.get(fieldname) is not None:
+                    continue
+                filters[fieldname] = default
 
         except Exception as e:
             # Log error but don't fail the report execution

--- a/frappe_assistant_core/tests/test_report_filter_contract.py
+++ b/frappe_assistant_core/tests/test_report_filter_contract.py
@@ -1,0 +1,407 @@
+# Frappe Assistant Core - AI Assistant integration for Frappe Framework
+# Copyright (C) 2025 Paul Clinton
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression tests for: https://github.com/buildswithpaul/Frappe_Assistant_Core/issues/229
+
+report_requirements is the discovery tool a model is told to call before
+generate_report, and the two disagreed about their own contract: the validator
+carried a hardcoded fieldname -> accepted-values map that had nothing to do with
+the report being run.
+
+`range` alone means four different things across the standard apps:
+
+  * Data ageing buckets — "30, 60, 90, 120" on Accounts Payable/Receivable
+    (+ Summary) and "30, 60, 90" on Stock Ageing. The map rejected every one of
+    these advertised defaults.
+  * Weekly|Monthly|Quarterly|Half-Yearly|Yearly on Sales and Stock Analytics.
+  * Daily|Weekly|Monthly on Website Analytics — 'Daily' was rejected.
+  * Monthly|Quarterly on Sales Pipeline Analytics — the map accepted 'Weekly',
+    which that report does not offer.
+
+Validation is now driven by the report's own declared filter definitions, the
+same discovery report_requirements advertises from. The contract test at the
+bottom is the audit: it asserts every advertised default is executable, for every
+report report_list exposes.
+"""
+
+from unittest.mock import MagicMock
+
+import frappe
+
+from frappe_assistant_core.plugins.core.tools.report_requirements import (
+    ReportRequirements,
+    discover_filter_definitions,
+    normalize_filter_options,
+)
+from frappe_assistant_core.plugins.core.tools.report_tools import ReportTools
+from frappe_assistant_core.tests.base_test import BaseAssistantTest
+
+# The real Accounts Payable Summary and Sales Pipeline Analytics contracts, which
+# assign incompatible meanings to the same fieldname.
+AGEING_RANGE = {
+    "fieldname": "range",
+    "label": "Ageing Range",
+    "fieldtype": "Data",
+    "default": "30, 60, 90, 120",
+}
+PERIODICITY_RANGE = {
+    "fieldname": "range",
+    "label": "Range",
+    "fieldtype": "Select",
+    "options": ["Monthly", "Quarterly"],
+    "default": "Monthly",
+}
+
+
+def report_stub(name="Test Report", report_type="Script Report"):
+    doc = MagicMock()
+    doc.name = name
+    doc.report_type = report_type
+    return doc
+
+
+class TestNormalizeFilterOptions(BaseAssistantTest):
+    """A constrained value set must be advertised as an explicit list of values."""
+
+    def test_escaped_newline_string_becomes_a_list(self):
+        """Read from a .js file, so the newline arrives as a literal backslash-n."""
+        filter_def = normalize_filter_options(
+            {"fieldname": "range", "fieldtype": "Select", "options": "Monthly\\nQuarterly"}
+        )
+        self.assertEqual(filter_def["options"], ["Monthly", "Quarterly"])
+
+    def test_real_newline_string_becomes_a_list(self):
+        """A Report.filters child-table row carries a real newline."""
+        filter_def = normalize_filter_options(
+            {"fieldname": "ageing_based_on", "fieldtype": "Select", "options": "Posting Date\nDue Date"}
+        )
+        self.assertEqual(filter_def["options"], ["Posting Date", "Due Date"])
+
+    def test_list_options_are_cleaned(self):
+        filter_def = normalize_filter_options(
+            {"fieldname": "range", "fieldtype": "Select", "options": [" Weekly ", "", "Monthly"]}
+        )
+        self.assertEqual(filter_def["options"], ["Weekly", "Monthly"])
+
+    def test_autocomplete_is_also_value_constrained(self):
+        filter_def = normalize_filter_options(
+            {"fieldname": "party_type", "fieldtype": "Autocomplete", "options": "Customer\\nSupplier"}
+        )
+        self.assertEqual(filter_def["options"], ["Customer", "Supplier"])
+
+    def test_link_options_are_a_doctype_not_a_value_set(self):
+        filter_def = normalize_filter_options(
+            {"fieldname": "company", "fieldtype": "Link", "options": "Company"}
+        )
+        self.assertEqual(filter_def["options"], "Company", "a Link target must stay a DocType name")
+
+    def test_missing_options_left_alone(self):
+        filter_def = normalize_filter_options({"fieldname": "range", "fieldtype": "Data"})
+        self.assertNotIn("options", filter_def)
+
+
+class TestOptionsArrayParsing(BaseAssistantTest):
+    """Option arrays are parsed straight out of report JS."""
+
+    def setUp(self):
+        super().setUp()
+        self.tool = ReportRequirements()
+
+    def _options_for(self, js_options):
+        parsed = self.tool._parse_js_filter_array(
+            f'{{ fieldname: "group_by", fieldtype: "Select", options: {js_options} }}'
+        )
+        return parsed["filters"][0].get("options")
+
+    def test_empty_first_option_does_not_shift_the_values(self):
+        """Regression: a leading "" made naive quote-pairing capture the separators.
+
+        POS Register advertised options of [", ", ", ", ", ", ", "] because of this.
+        """
+        self.assertEqual(
+            self._options_for('["", "POS Profile", "Cashier", "Payment Method", "Customer"]'),
+            ["POS Profile", "Cashier", "Payment Method", "Customer"],
+        )
+
+    def test_plain_string_array(self):
+        self.assertEqual(self._options_for('["Value", "Quantity"]'), ["Value", "Quantity"])
+
+    def test_value_label_object_array_returns_values_only(self):
+        self.assertEqual(
+            self._options_for(
+                '[{ value: "Daily", label: __("Daily") }, { value: "Weekly", label: __("Weekly") }]'
+            ),
+            ["Daily", "Weekly"],
+        )
+
+    def test_translated_string_array(self):
+        self.assertEqual(self._options_for('[__("Open"), __("Closed")]'), ["Open", "Closed"])
+
+
+class TestDefinitionDrivenValidation(BaseAssistantTest):
+    """Accepted values come from the report being run, not from a global guess."""
+
+    def _validate(self, filters, definitions):
+        return ReportTools._validate_filters(filters, report_stub(), definitions)
+
+    def test_ageing_range_default_is_accepted(self):
+        """The reported failure: the advertised default was rejected outright."""
+        result = self._validate({"range": "30, 60, 90, 120"}, {"range": AGEING_RANGE})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_stock_ageing_range_default_is_accepted(self):
+        result = self._validate({"range": "30, 60, 90"}, {"range": dict(AGEING_RANGE, default="30, 60, 90")})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_periodicity_range_accepts_its_own_option(self):
+        result = self._validate({"range": "Monthly"}, {"range": PERIODICITY_RANGE})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_periodicity_range_rejects_a_value_it_does_not_offer(self):
+        """The map accepted Weekly here; Sales Pipeline Analytics does not offer it."""
+        result = self._validate({"range": "Weekly"}, {"range": PERIODICITY_RANGE})
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["error_details"][0]["type"], "invalid_option")
+        self.assertEqual(result["error_details"][0]["accepted_values"], ["Monthly", "Quarterly"])
+
+    def test_error_message_lists_the_accepted_values(self):
+        """Preserved from the previous behaviour, and now the values are correct."""
+        result = self._validate({"range": "Weekly"}, {"range": PERIODICITY_RANGE})
+
+        self.assertIn("Must be one of: Monthly, Quarterly", result["errors"][0])
+
+    def test_same_fieldname_validated_differently_per_report(self):
+        """One fieldname, two reports, two contracts — the point of the fix."""
+        self.assertTrue(self._validate({"range": "30, 60, 90, 120"}, {"range": AGEING_RANGE})["valid"])
+        self.assertFalse(self._validate({"range": "30, 60, 90, 120"}, {"range": PERIODICITY_RANGE})["valid"])
+
+    def test_undeclared_filter_is_not_second_guessed(self):
+        """Guessing at a filter the report never declared is what caused this bug."""
+        result = self._validate({"range": "anything at all"}, {})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_multi_value_selection_is_not_treated_as_an_enum_choice(self):
+        result = self._validate({"range": ["Monthly", "Quarterly"]}, {"range": PERIODICITY_RANGE})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_empty_values_are_skipped(self):
+        result = self._validate({"range": "", "other": None}, {"range": PERIODICITY_RANGE})
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_invalid_date_is_reported(self):
+        result = self._validate(
+            {"report_date": "not a date"}, {"report_date": {"fieldname": "report_date", "fieldtype": "Date"}}
+        )
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["error_details"][0]["type"], "invalid_date")
+
+    def test_unambiguous_alternative_date_format_is_accepted(self):
+        """getdate() is deliberately lenient; only unparseable input is an error."""
+        result = self._validate(
+            {"report_date": "31-12-2024"}, {"report_date": {"fieldname": "report_date", "fieldtype": "Date"}}
+        )
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_valid_date_passes(self):
+        result = self._validate(
+            {"report_date": "2024-12-31"}, {"report_date": {"fieldname": "report_date", "fieldtype": "Date"}}
+        )
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_unknown_link_record_is_reported_with_suggestions(self):
+        definitions = {"company": {"fieldname": "company", "fieldtype": "Link", "options": "Company"}}
+        result = self._validate({"company": "No Such Company 229"}, definitions)
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["error_details"][0]["type"], "unknown_record")
+        self.assertEqual(result["error_details"][0]["target_doctype"], "Company")
+
+    def test_existing_link_record_passes(self):
+        company = frappe.db.get_value("Company", {}, "name")
+        if not company:
+            self.skipTest("no Company records on this site")
+
+        definitions = {"company": {"fieldname": "company", "fieldtype": "Link", "options": "Company"}}
+        result = self._validate({"company": company}, definitions)
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_link_options_naming_a_companion_field_is_not_a_doctype(self):
+        """Accounts Payable Summary's `party` has options: "party_type", a fieldname."""
+        definitions = {"party": {"fieldname": "party", "fieldtype": "Link", "options": "party_type"}}
+        result = self._validate({"party": "Some Supplier"}, definitions)
+
+        self.assertTrue(result["valid"], result["errors"])
+
+
+class TestFilterDefaultsUseSharedDiscovery(BaseAssistantTest):
+    """Auto-applied defaults come from the same definitions that are advertised."""
+
+    def test_declared_defaults_are_applied(self):
+        filters = {}
+        ReportTools._apply_filter_defaults(report_stub(), filters, {"range": AGEING_RANGE})
+
+        self.assertEqual(filters["range"], "30, 60, 90, 120")
+
+    def test_caller_values_are_never_overridden(self):
+        filters = {"range": "15, 30"}
+        ReportTools._apply_filter_defaults(report_stub(), filters, {"range": AGEING_RANGE})
+
+        self.assertEqual(filters["range"], "15, 30")
+
+    def test_definitions_without_defaults_add_nothing(self):
+        filters = {}
+        ReportTools._apply_filter_defaults(
+            report_stub(), filters, {"company": {"fieldname": "company", "fieldtype": "Link"}}
+        )
+
+        self.assertEqual(filters, {})
+
+    def test_applied_default_passes_validation(self):
+        """The two halves of the contract, checked against each other."""
+        definitions = {"range": AGEING_RANGE}
+        filters = ReportTools._apply_filter_defaults(report_stub(), {}, definitions)
+
+        self.assertTrue(ReportTools._validate_filters(filters, report_stub(), definitions)["valid"])
+
+
+class TestAdvertisedDefaultsAreExecutable(BaseAssistantTest):
+    """The contract test: what report_requirements advertises, generate_report accepts.
+
+    This is the test that would have caught the original mismatch, and it is the
+    standing audit across every report report_list exposes.
+    """
+
+    def _exposed_reports(self, report_type):
+        listing = ReportTools.list_reports(report_type=report_type)
+        self.assertTrue(listing.get("success"), listing)
+        return [r for r in listing.get("reports", []) if not r.get("disabled")]
+
+    def _contract_failures(self, report_type):
+        failures = []
+        checked = 0
+        tool = ReportRequirements()
+
+        for report in self._exposed_reports(report_type):
+            try:
+                requirements = tool.execute({"report_name": report.name, "include_columns": False})
+            except Exception as e:
+                failures.append(f"{report.name}: report_requirements raised {type(e).__name__}: {e}")
+                continue
+
+            if not requirements.get("success"):
+                continue
+
+            definitions = requirements.get("filters_definition") or []
+            advertised = {
+                d["fieldname"]: d["default"]
+                for d in definitions
+                if d.get("fieldname") and d.get("default") not in (None, "")
+            }
+
+            # A constrained filter must advertise its default as one of its own values.
+            for definition in definitions:
+                options = definition.get("options")
+                default = definition.get("default")
+                if definition.get("fieldtype") != "Select" or not isinstance(options, list) or not options:
+                    continue
+                if default and default not in options:
+                    failures.append(
+                        f"{report.name}.{definition['fieldname']}: default {default!r} "
+                        f"is not among its advertised options {options}"
+                    )
+
+            if not advertised:
+                continue
+
+            checked += 1
+            report_doc = frappe.get_doc("Report", report.name)
+            validation = ReportTools._validate_filters(dict(advertised), report_doc)
+
+            for detail in validation.get("error_details", []):
+                # A missing record depends on this instance's data, not on the
+                # advertise/validate contract.
+                if detail["type"] == "unknown_record":
+                    continue
+                failures.append(
+                    f"{report.name}.{detail['fieldname']}: advertised default {detail['value']!r} "
+                    f"rejected as {detail['type']} (accepted: {detail.get('accepted_values')})"
+                )
+
+        return failures, checked
+
+    def test_script_report_advertised_defaults_are_accepted(self):
+        failures, checked = self._contract_failures("Script Report")
+
+        if not checked:
+            self.skipTest("no Script Reports with advertised defaults on this site")
+        self.assertEqual(
+            failures, [], f"{len(failures)} advertise/validate mismatches across {checked} Script Reports"
+        )
+
+    def test_query_report_advertised_defaults_are_accepted(self):
+        failures, _checked = self._contract_failures("Query Report")
+
+        self.assertEqual(failures, [], f"{len(failures)} advertise/validate mismatches in Query Reports")
+
+    def test_known_offenders_now_pass(self):
+        """The six reports the audit surfaced, named so a regression is unambiguous."""
+        offenders = {
+            "Accounts Payable": "30, 60, 90, 120",
+            "Accounts Payable Summary": "30, 60, 90, 120",
+            "Accounts Receivable": "30, 60, 90, 120",
+            "Accounts Receivable Summary": "30, 60, 90, 120",
+            "Stock Ageing": "30, 60, 90",
+            "Website Analytics": "Daily",
+        }
+
+        tested = 0
+        for report_name, advertised_range in offenders.items():
+            if not frappe.db.exists("Report", report_name):
+                continue
+            tested += 1
+            report_doc = frappe.get_doc("Report", report_name)
+            definitions = discover_filter_definitions(report_doc)
+            self.assertIn("range", definitions, f"{report_name} must declare a range filter")
+
+            result = ReportTools._validate_filters({"range": advertised_range}, report_doc, definitions)
+            self.assertTrue(result["valid"], f"{report_name}: {result['errors']}")
+
+        if not tested:
+            self.skipTest("none of the audited reports are installed")
+
+    def test_sales_pipeline_analytics_rejects_weekly(self):
+        """The permissive half of the same bug, against live metadata."""
+        if not frappe.db.exists("Report", "Sales Pipeline Analytics"):
+            self.skipTest("Sales Pipeline Analytics not installed")
+
+        report_doc = frappe.get_doc("Report", "Sales Pipeline Analytics")
+        definitions = discover_filter_definitions(report_doc)
+        self.assertEqual(definitions["range"]["options"], ["Monthly", "Quarterly"])
+
+        result = ReportTools._validate_filters({"range": "Weekly"}, report_doc, definitions)
+        self.assertFalse(result["valid"], "Weekly is not an option this report offers")


### PR DESCRIPTION
Fixes #229

Branches off `develop` — no dependency on #231 / #232.

## Root cause

`_validate_filters` carried a hardcoded `fieldname -> accepted values` map, applied to every report regardless of what that report declares. That was the second source of truth.

`range` alone means **four** different things across the standard apps:

| Report | fieldtype | Accepted values | Old map's verdict |
|---|---|---|---|
| Accounts Payable / Receivable (+ Summary) | `Data` | `"30, 60, 90, 120"` | ❌ rejected the advertised default |
| Stock Ageing | `Data` | `"30, 60, 90"` | ❌ rejected the advertised default |
| Sales Analytics, Stock Analytics | `Select` | Weekly…Yearly | ✅ correct, by luck |
| Website Analytics (frappe core) | `Select` | Daily, Weekly, Monthly | ❌ rejected `Daily` |
| Sales Pipeline Analytics | `Select` | Monthly, Quarterly | ❌ **accepted `Weekly`**, which the report does not offer |

So the map was wrong in both directions — rejecting valid values and accepting invalid ones.

## Change

**One source of truth.** New `discover_filter_definitions(report_doc)` in `report_requirements.py` returns the report's contract as `{fieldname: definition}`. `report_requirements` advertises from it and `generate_report` validates against it, so the two cannot drift.

Validation is now per-report: a constrained value set (`Select`, `Autocomplete`) is checked against *that report's* options; a `Link` value against the DocType *it* names; a `Date` value for parseability. **A filter the report does not declare is left alone** — guessing is what created this bug, and the report itself then raises a real error.

**The third copy is gone too.** `_apply_filter_defaults` had its own JS regex that could disagree with the advertised definitions; it now reads the shared discovery. Defaults advertised, defaults applied, and values accepted are one thing. Net −95 lines of duplicated parsing.

**Two further mismatches the audit surfaced (AC2):**

- Select options declared as a newline-delimited string reached callers as an opaque `"Monthly\nQuarterly"`, while array-declared options arrived as a list — the same contract in two shapes, and unusable in the string case. Constrained sets are now always an explicit list.
- A leading `""` in an options array (the "no selection" entry) threw naive quote-pairing off by one, so **POS Register advertised its `group_by` options as `[", ", ", ", ", ", ", "]`**. String literals are now scanned properly. This was a pre-existing garbage-in-the-contract bug; making the validator consume the definitions turned it into a hard failure, which is how it got caught.

**Richer errors.** Validation failures now also return `error_details` — `[{fieldname, type, value, accepted_values}]` with `type` in `invalid_option` / `unknown_record` / `invalid_date` — so a consumer can react programmatically instead of parsing prose. The existing human-readable `validation_errors` are unchanged in shape and now list the *correct* accepted values.

## Audit (AC2)

Ran across every exposed report on a live instance — 191 Script Reports plus Query and Custom Reports; 87 reports advertise 171 literal default values; 157 constrained filters:

| | Before | After |
|---|---|---|
| Advertise/validate mismatches | **6** | **0** |
| Raw-string (unusable) option sets | 1 | 0 |
| Corrupted option sets | 1 (POS Register) | 0 |

The six: Accounts Payable, Accounts Payable Summary, Accounts Receivable, Accounts Receivable Summary, Stock Ageing, Website Analytics. Whole audit runs in ~3s, which is why it could become a test.

## Verification

End-to-end on a live instance, all `success: true` with defaults auto-applied from the shared discovery:

| Report | rows | auto-applied `range` |
|---|---|---|
| Accounts Payable Summary | 4 | `30, 60, 90, 120` |
| Accounts Receivable Summary | 3 | `30, 60, 90, 120` |
| Stock Ageing | 13 | `30, 60, 90` |
| Sales Analytics | 0 | `Monthly` |
| Website Analytics | 0 | `Daily` |
| General Ledger | 4 | — |

The originally reported call — advertised default `"30, 60, 90, 120"` passed straight into `generate_report` — went from `success: false` to `success: true`.

34 new tests in `test_report_filter_contract.py`. Full suite: 235 passed. `pre-commit run` clean.

## Acceptance criteria

- [x] `range` filter metadata matches validator expectations
- [x] Audit completed across all exposed Script Reports; two further mismatches found and fixed in this PR (raw-string options, corrupted option array)
- [x] Contract test in place asserting advertised defaults are executable for every exposed report
- [x] Validation error messages list the accepted values — preserved, and now correct per report

## Notes for reviewers

- **Behaviour change: fewer pre-flight rejections.** Filters a report doesn't declare are no longer validated, so a bad value reaches the report and surfaces as the report's own error rather than a guessed one. This is deliberate — the guessing was the bug — but it does mean some errors now arrive later and worded by Frappe.
- **Link validation is now definition-driven**, replacing the fixed `company`/`customer`/`supplier`/… list. Reports that declare these as Link filters (nearly all) keep the existence check and the "Did you mean…?" suggestions; a report that declares `company` as something else no longer gets a Company existence check applied to it.
- `_validate_filters`, `_apply_filter_defaults` and `_execute_script_report` take an optional `definitions` argument so `execute_report` resolves the contract once per call rather than re-reading JS per code path.
