### PR TITLE
docs: document that FAC reads schema live and keeps no cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,40 @@ Full specification for each tool is in the
 
 ---
 
+## Schema access is live
+
+FAC reads your schema from Frappe's metadata API at the moment a tool is
+called. It keeps no schema copy of its own — no snapshot table, no
+embedded or vector index of your data model, and no sync command. There
+is nothing to re-run and no staleness window to reason about.
+
+In practice that means:
+
+- **Custom DocTypes, Custom Fields, and Property Setters are visible on
+  the next tool call.** Create a field in the desk and the LLM sees it
+  immediately. `get_doctype_info` returns custom fields merged inline
+  with standard fields, along with child-table field definitions, Link
+  targets, and the DocType's permission rules.
+- **Renames, added options, and changed labels take effect the same
+  way** — they come from the same live metadata read.
+- **Permissions are evaluated per call against the requesting user**,
+  never snapshotted. FAC asks Frappe on each call, so a role change
+  applies as soon as Frappe applies it.
+
+FAC does cache a few operational things — whether the server is
+enabled, the MCP and OAuth endpoint URLs, and dashboard/health
+statistics. None of them describe your schema or your data.
+
+If you reach FAC through another product that embeds or orchestrates it,
+that layer may maintain its own schema cache with its own refresh
+behaviour. Staleness seen through a wrapper is worth tracing there
+first; FAC itself has no such step.
+
+Implementation details are in
+[Architecture Overview](docs/internals/INTERNALS.md#schema-access).
+
+---
+
 ## Extend with your own tools
 
 If you have a Frappe app and want the LLM to reach into it, use the

--- a/docs/internals/INTERNALS.md
+++ b/docs/internals/INTERNALS.md
@@ -565,6 +565,61 @@ Tool Registration
 Lifecycle Hook Execution
 ```
 
+## Schema Access
+
+FAC holds no representation of your data model. Every schema read goes to
+Frappe's metadata API at call time, which is why customisations need no sync
+step and there is no staleness window FAC could introduce.
+
+### 1. Where Schema Comes From
+
+| Need | Call path | Source |
+|------|-----------|--------|
+| Fields, Link targets, child tables, DocPerms | `metadata_tools.get_doctype_metadata()` → `frappe.get_meta(doctype)` | Live metadata API |
+| Child-table row structure | `frappe.get_meta(child_doctype)` per table field | Live metadata API |
+| Available DocTypes (incl. custom) | `metadata_tools.list_doctypes()` → `frappe.get_all("DocType", ...)` | Live table read |
+| Submittable / naming / title field | `frappe.get_meta(doctype)` attributes | Live metadata API |
+| Report filter contracts | `ReportRequirements._discover_report_filters()` | `Report` doc, its `filters` child table, and the report's own JS, read per call |
+
+`frappe.get_meta()` merges Custom Fields and Property Setters into the
+DocType definition, so a customisation appears in the very next tool call.
+Frappe maintains its own metadata cache and invalidates it when a DocType,
+Custom Field, or Property Setter is saved; FAC adds no second layer in
+front of it and holds no copy that could diverge.
+
+### 2. What This Rules Out
+
+FAC's DocType footprint is `Assistant Core Settings`, `Assistant Audit Log`,
+`FAC Plugin Configuration`, `FAC Tool Configuration`, `FAC Tool Role Access`,
+`FAC Skill`, and the Prompt Template family. None of them stores schema.
+
+There is no schema snapshot table, no embedding or vector index of the data
+model, and no `sync`/`refresh-schema` command — because there is nothing to
+sync. The optional ChatGPT-facing `search` and `fetch` tools run Frappe's
+own search at call time rather than querying an index FAC maintains.
+
+### 3. Permissions Are Evaluated Per Call
+
+Permission decisions are made during the call, against the requesting user:
+
+- `validate_document_access()` and `frappe.has_permission()` run per tool call
+- Document queries use `frappe.get_list(..., ignore_permissions=False)`, so
+  Frappe applies DocType permissions, User Permissions, and row-level
+  restrictions to every result set
+- DocPerms returned by `get_doctype_info` come from the live meta read
+
+FAC caches no permission decision on the request path. The role and user
+permission data underneath comes from Frappe's own cache, which Frappe
+invalidates when roles change.
+
+### 4. Downstream Caching
+
+Products that embed or orchestrate FAC may add their own schema cache with
+their own refresh semantics. That is a reasonable thing for an orchestration
+layer to do, and it is outside FAC's boundary — staleness observed through
+such a layer is best traced there, since FAC performs no caching of schema
+itself.
+
 ## Security Architecture
 
 Frappe Assistant Core implements a **comprehensive multi-layer security framework** that provides enterprise-grade security for AI assistant operations in business environments.
@@ -767,9 +822,13 @@ def audit_log_tool_access(user, tool_name, arguments, result):
 
 - **Plugin State**: Plugin states persisted in database
 - **Tool Registry**: Efficient tool discovery and registration
-- **Permission Results**: Cached with TTL through Frappe
-- **Configuration**: Hierarchical configuration caching
-- **Metadata**: DocType metadata cached through Frappe
+- **Configuration**: Server settings (enabled flag, MCP and OAuth endpoint URLs) cached for 30 minutes, invalidated on `Assistant Core Settings` update
+- **Statistics**: Dashboard, analytics, and health figures cached for 5–10 minutes
+
+**Not cached by FAC**: DocType metadata and permission decisions. Both are
+read live on every call — see [Schema Access](#schema-access). FAC stores no
+schema snapshot of its own, so there is no sync step and no staleness window
+it can introduce.
 
 ### 2. Lazy Loading
 


### PR DESCRIPTION
Fixes #230

Branches off `develop`, docs only — no dependency on #231 / #232 / #233.

## Change

- **README** — new "Schema access is live" section: schema is read from Frappe's metadata API at call time; no snapshot table, no embedded or vector index, no sync command; custom DocTypes / Custom Fields / Property Setters are visible on the next tool call; permissions are evaluated per call.
- **`docs/internals/INTERNALS.md`** — new "Schema Access" section with the actual call paths, what having no schema store rules out, how permissions are resolved, and a note on downstream caching.

## The architecture doc was part of the problem

Worth flagging, because it changes how the misattribution reads. `INTERNALS.md` listed these under **FAC's** "Caching Strategy":

```
- **Permission Results**: Cached with TTL through Frappe
- **Metadata**: DocType metadata cached through Frappe
```

A reader auditing FAC would reasonably conclude it holds a cached schema snapshot and cached permission decisions. Neither is a FAC cache: metadata comes from `frappe.get_meta()` per call, and permission decisions are made during the call. The section now lists what FAC actually caches and names metadata and permissions as explicitly **not** cached.

So the report's assumption had a plausible source in our own docs, not just in the wrapper layer.

## Verified before documenting

I did not take the issue's findings on trust — each claim was checked against this instance and the codebase:

| Claim | How it was checked | Result |
|---|---|---|
| Custom Fields appear with no sync step | Inserted a Custom Field on `ToDo`, called `get_doctype_info` | Visible in the very next call, merged inline with standard fields |
| Property Setters apply immediately | Added a label Property Setter on `ToDo.status` | New label returned by the next call |
| Permissions evaluated per call | `MetadataTools.get_permissions()`, `validate_document_access()`, `frappe.get_list(ignore_permissions=False)` | Resolved per call against the session user |
| No schema store | FAC's DocType footprint | 9 DocTypes: settings, audit log, plugin/tool config, tool role access, skill, prompt template family — none holds schema |
| No embedding / vector index | grep for `embed`/`vector` across the app | Only a chart tag, a pandas hint, and an HTML-sanitiser regex. The ChatGPT-facing `search`/`fetch` tools call `SearchTools.global_search` — Frappe's own search — not an index FAC maintains |
| No sync step | grep for `sync_schema` / `refresh_schema` / `schema_cache`; checked for a bench commands module | None exist |
| What FAC *does* cache | `utils/cache.py` + `hooks.py` | Server settings 30 min (invalidated on settings update), dashboard/analytics/health 5–10 min, tool registry stats 1 h. Nothing schema-related |

**Test artifacts were cleaned up.** The Custom Field persisted despite an intended rollback — adding a field triggers DDL, which implicitly commits in MariaDB — so I removed the row and the `tabToDo` column explicitly and confirmed `ToDo` is back to 18 fields with `status` labelled "Status". The Property Setter did roll back on its own.

## Acceptance criteria

- [x] README section added
- [x] Architecture doc updated — `docs/internals/INTERNALS.md`, and the misleading Caching Strategy entries corrected
- [x] Wording is neutral toward downstream integrators — describes FAC's behaviour, states that a wrapper maintaining its own cache is reasonable and simply outside FAC's boundary, assigns no blame

## Two unrelated findings, not fixed here

1. **`utils/cache.py` has dead constants that imply a schema cache** — `CACHE_TTL["metadata"] = 3600  # 1 hour - DocType metadata` and `CACHE_KEYS["metadata"] = "assistant_meta"` are declared but never used, as is `get_cached_user_tool_permissions()`. They are the same trip-hazard as the doc bullets. Happy to remove them in a separate `refactor:` PR — kept out of a docs-only change.
2. **`docs/skills/search_vector.md` looks inaccurate** — it says `search` and `fetch` "require a configured vector store (e.g., OpenAI Vector Store)" and return empty results without one. `chatgpt_search.py` delegates to `SearchTools.global_search`, so that appears to be wrong. Worth its own issue.
