### PR TITLE
Filter out draft and cancelled docs when listing submittable DocTypes

### DIFF
--- a/frappe_assistant_core/plugins/core/tools/list_documents.py
+++ b/frappe_assistant_core/plugins/core/tools/list_documents.py
@@ -134,6 +134,19 @@ class DocumentList(BaseTool):
                     filtered_fields = ["name"]  # Always allow name field
                 fields = filtered_fields
 
+            # For submittable DocTypes, default to submitted documents (docstatus=1)
+            # unless the caller has explicitly provided a docstatus filter.
+            # Without this, cancelled (docstatus=2) and draft (docstatus=0) documents
+            # with stale field values such as outstanding_amount appear alongside
+            # submitted ones and produce phantom balances or incorrect totals.
+            if "docstatus" not in (filters or {}):
+                try:
+                    if frappe.get_meta(doctype).is_submittable:
+                        filters = dict(filters or {})
+                        filters["docstatus"] = 1
+                except Exception:
+                    pass
+
             # Get documents with Frappe's permission-aware list API.
             documents = frappe.get_list(
                 doctype,


### PR DESCRIPTION
When you call `list_documents` on a submittable DocType (Sales Invoice, Payment Entry, etc.) without a `docstatus` filter, you get drafts and cancelled records back alongside submitted ones. Those records often carry stale financial fields, so anything downstream that aggregates them ends up with phantom numbers.

The fix checks `frappe.get_meta(doctype).is_submittable` at query time. If the DocType is submittable and no `docstatus` was passed, we automatically inject `docstatus=1` so only submitted docs come back. The injected filter shows up in the `filters_applied` key of the response so callers can see it was added. If the caller explicitly passes their own `docstatus` we leave it alone — this only kicks in when nothing was specified.

Tested on a local bench: listing Sales Invoice with no filter now returns only submitted records. Passing `docstatus: 0` still returns drafts as expected.

Fixes #227