### PR TITLE
ci: stop the MariaDB client install from hanging the server job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             python-version: '3.14'
             node-version: 24
     name: Server (${{ matrix.frappe-branch }})
+    timeout-minutes: 30
 
     services:
       redis-cache:
@@ -84,9 +85,12 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install MariaDB Client
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt update
-          sudo apt-get install mariadb-client
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mariadb-client
 
       - name: Setup
         run: |


### PR DESCRIPTION
## Summary

`Server (version-16)` hung twice in a row on **Install MariaDB Client** — 27 minutes on the first attempt, 18 on the re-run — never reaching `Setup` or `Run Tests`. `Server (version-15)` passed the identical step in ~4 minutes on the same commit both times. Observed on #240; it is not specific to that PR.

Two things made it a 6-hour block rather than a 3-minute failure:

1. `apt-get install mariadb-client` had no `-y`. Any confirmation prompt waits on stdin forever.
2. The job sets no `timeout-minutes`, so a stalled step runs to GitHub's 6-hour default. Combined with `cancel-in-progress` concurrency, the PR's checks stay `pending` the whole time and there is nothing to re-run.

I could not pin down whether it was `apt-get update` hitting a slow mirror or `apt-get install` waiting on a prompt — the logs are not retrievable while a job is in progress, and both attempts were cancelled before the step ever completed. Notably v15 passes the same step on the same runner image, which argues against the prompt being the whole story. So this fixes both possibilities rather than guessing:

## What changed

```diff
       - name: Install MariaDB Client
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt update
-          sudo apt-get install mariadb-client
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mariadb-client
```

plus `timeout-minutes: 30` on the `tests` job.

- `-y` + `DEBIAN_FRONTEND=noninteractive` remove any possibility of an interactive wait. `--no-install-recommends` keeps the install to what the `Setup` step actually needs (`mariadb` CLI for the two `SET GLOBAL` statements).
- `-qq` on `update` cuts the per-mirror chatter.
- The two timeouts are the part that matters regardless of cause: a stall now surfaces as a **failed** check within five minutes, which is re-runnable, instead of an in-progress one for six hours, which is not.

## Type of Change
- [x] CI / infrastructure

## Testing

Nothing to unit-test — the change is the workflow that runs the tests, and it takes effect on this PR's own run. Both `Server` legs passing here is the verification. `apt-get update -qq` + `install -y --no-install-recommends mariadb-client` is the standard non-interactive form and installs the same `mariadb` client binary the `Setup` step invokes.

`ci:` prefix, so semantic-release will not cut a version for it.

## Note

#240 is blocked behind this. Once this lands I will rebase that branch onto `develop` so it picks up the fixed workflow — re-running the existing checks would replay the old workflow file, so a fresh run is needed rather than a re-run.
